### PR TITLE
refactor(cli): per-command option adapters using Zod block schemas

### DIFF
--- a/apps/cli/src/app/cli-errors.spec.ts
+++ b/apps/cli/src/app/cli-errors.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { exitCodeFor, mutableFromCli } from './cli-errors';
+
+describe('exitCodeFor', () => {
+  it('returns 1 for query', () => {
+    expect(exitCodeFor('query')).toBe(1);
+  });
+
+  it('returns 1 for serve', () => {
+    expect(exitCodeFor('serve')).toBe(1);
+  });
+
+  it('returns 2 for diff', () => {
+    expect(exitCodeFor('diff')).toBe(2);
+  });
+
+  it('returns 1 for hash by default', () => {
+    expect(exitCodeFor('hash')).toBe(1);
+  });
+
+  it('returns 2 for hash in compare-with mode', () => {
+    expect(exitCodeFor('hash', { hashCompareMode: true })).toBe(2);
+  });
+});
+
+describe('mutableFromCli', () => {
+  it('returns undefined when neither flag is set', () => {
+    expect(mutableFromCli({})).toBeUndefined();
+  });
+
+  it('--mutable returns true', () => {
+    expect(mutableFromCli({ mutable: true })).toBe(true);
+  });
+
+  it('--immutable=false returns true', () => {
+    expect(mutableFromCli({ immutable: false })).toBe(true);
+  });
+
+  it('--immutable=true returns false', () => {
+    expect(mutableFromCli({ immutable: true })).toBe(false);
+  });
+
+  it('--mutable wins over --immutable', () => {
+    expect(mutableFromCli({ mutable: true, immutable: true })).toBe(true);
+  });
+});

--- a/apps/cli/src/app/cli-errors.ts
+++ b/apps/cli/src/app/cli-errors.ts
@@ -1,0 +1,78 @@
+import type { z } from 'zod';
+import type { CommandName } from './config/internal/schema';
+
+export type AdapterErrorKind =
+  | 'unknown-flag'
+  | 'positional-overflow'
+  | 'invalid';
+
+export interface AdapterError {
+  kind: AdapterErrorKind;
+  message: string;
+}
+
+export type AdapterResult<T> =
+  | { cliOverrides: T }
+  | { errors: AdapterError[] };
+
+export function isAdapterFailure<T>(
+  r: AdapterResult<T>,
+): r is { errors: AdapterError[] } {
+  return (r as { errors?: AdapterError[] }).errors !== undefined;
+}
+
+const FIELD_TO_FLAG: Record<string, string> = {
+  graphStrategy: '--graph-strategy',
+  format: '--format',
+  sources: '--sources',
+  queryFile: '--query-file',
+  query: '--query',
+  port: '--port',
+  watch: '--watch',
+  watchDebounce: '--watch-debounce',
+  compareWith: '--compare-with',
+  json: '--json',
+  mutable: '--mutable',
+  immutable: '--immutable',
+  left: '--left',
+  right: '--right',
+  verbose: '--verbose',
+  quiet: '--quiet',
+};
+
+export function formatZodIssues(
+  issues: ReadonlyArray<z.core.$ZodIssue>,
+  rawValues: Record<string, unknown>,
+): AdapterError[] {
+  return issues.map((issue) => {
+    const key = String(issue.path[0] ?? '');
+    const flag = FIELD_TO_FLAG[key] ?? `--${key}`;
+    if (issue.code === 'invalid_value' && Array.isArray(issue.values)) {
+      const offered = rawValues[key];
+      const expected = issue.values.join(', ');
+      return {
+        kind: 'unknown-flag',
+        message: `unknown ${flag} '${String(offered)}' (expected ${expected})`,
+      };
+    }
+    return { kind: 'invalid', message: `${flag}: ${issue.message}` };
+  });
+}
+
+export function exitCodeFor(
+  command: CommandName,
+  context: { hashCompareMode?: boolean } = {},
+): number {
+  if (command === 'diff') return 2;
+  if (command === 'hash') return context.hashCompareMode ? 2 : 1;
+  return 1;
+}
+
+export function mutableFromCli(options: {
+  mutable?: boolean;
+  immutable?: boolean;
+}): boolean | undefined {
+  if (options.mutable === true) return true;
+  if (options.immutable !== undefined) return options.immutable === false;
+  return undefined;
+}

--- a/apps/cli/src/app/config/internal/schema.ts
+++ b/apps/cli/src/app/config/internal/schema.ts
@@ -1,4 +1,8 @@
 import { z } from 'zod';
+import { GRAPH_STRATEGIES, SUPPORTED_FORMATS } from 'core';
+
+export const DIFF_FORMATS = ['human', 'json', 'rdf-patch'] as const;
+export type DiffFormat = (typeof DIFF_FORMATS)[number];
 
 const coercedBoolean = z.preprocess((v) => {
   if (typeof v === 'string') {
@@ -24,7 +28,7 @@ interface FieldDef {
 const SHARED_FIELDS: Record<string, FieldDef> = {
   sources: { schema: z.string() },
   graphStrategy: {
-    schema: z.enum(['default', 'partial', 'full', 'none']),
+    schema: z.enum(GRAPH_STRATEGIES),
     default: 'default',
   },
   mutable: { schema: coercedBoolean, default: false },
@@ -35,7 +39,7 @@ const SHARED_FIELDS: Record<string, FieldDef> = {
 const QUERY_ONLY_FIELDS: Record<string, FieldDef> = {
   query: { schema: z.string() },
   queryFile: { schema: z.string() },
-  format: { schema: z.enum(['json', 'turtle']) },
+  format: { schema: z.enum(SUPPORTED_FORMATS) },
 };
 
 const SERVE_ONLY_FIELDS: Record<string, FieldDef> = {
@@ -56,7 +60,7 @@ const DIFF_ONLY_FIELDS: Record<string, FieldDef> = {
   left: { schema: z.union([z.string(), z.array(z.string()).min(1)]) },
   right: { schema: z.union([z.string(), z.array(z.string()).min(1)]) },
   format: {
-    schema: z.enum(['human', 'json', 'rdf-patch']),
+    schema: z.enum(DIFF_FORMATS),
     default: 'human',
   },
 };

--- a/apps/cli/src/app/diff.adapter.spec.ts
+++ b/apps/cli/src/app/diff.adapter.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isAdapterFailure } from './cli-errors';
+import { diffAdapter } from './diff.adapter';
+
+describe('diffAdapter', () => {
+  it('maps the two positionals to left/right', () => {
+    const result = diffAdapter(['a/*.ttl', 'b/*.ttl'], {});
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.left).toBe('a/*.ttl');
+    expect(result.cliOverrides.right).toBe('b/*.ttl');
+  });
+
+  it('--left and --right flags override positionals', () => {
+    const result = diffAdapter(['posL', 'posR'], {
+      left: 'flagL',
+      right: 'flagR',
+    });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.left).toBe('flagL');
+    expect(result.cliOverrides.right).toBe('flagR');
+  });
+
+  it('rejects more than two positionals with positional-overflow', () => {
+    const result = diffAdapter(['a', 'b', 'c'], {});
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0].kind).toBe('positional-overflow');
+    expect(result.errors[0].message).toBe(
+      'diff takes at most two positional arguments (got 3)',
+    );
+  });
+
+  it('rejects unknown --format with the canonical phrasing', () => {
+    const result = diffAdapter([], { format: 'csv' });
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0]).toEqual({
+      kind: 'unknown-flag',
+      message: "unknown --format 'csv' (expected human, json, rdf-patch)",
+    });
+  });
+
+  it('rejects unknown --graph-strategy', () => {
+    const result = diffAdapter([], { graphStrategy: 'bogus' });
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0]).toEqual({
+      kind: 'unknown-flag',
+      message:
+        "unknown --graph-strategy 'bogus' (expected default, partial, full, none)",
+    });
+  });
+});

--- a/apps/cli/src/app/diff.adapter.ts
+++ b/apps/cli/src/app/diff.adapter.ts
@@ -1,0 +1,44 @@
+import { blockSchemaFor, type EffectiveOptions } from './config/internal/schema';
+import { formatZodIssues, type AdapterResult } from './cli-errors';
+
+export interface DiffRawOptions {
+  left?: string;
+  right?: string;
+  graphStrategy?: string;
+  format?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+}
+
+export function diffAdapter(
+  passedParams: string[],
+  options: DiffRawOptions,
+): AdapterResult<Partial<EffectiveOptions>> {
+  if (passedParams.length > 2) {
+    return {
+      errors: [
+        {
+          kind: 'positional-overflow',
+          message: `diff takes at most two positional arguments (got ${passedParams.length})`,
+        },
+      ],
+    };
+  }
+
+  const raw: Record<string, unknown> = {};
+  if (passedParams[0] !== undefined) raw.left = passedParams[0];
+  if (passedParams[1] !== undefined) raw.right = passedParams[1];
+  if (options.left !== undefined) raw.left = options.left;
+  if (options.right !== undefined) raw.right = options.right;
+  if (options.graphStrategy !== undefined)
+    raw.graphStrategy = options.graphStrategy;
+  if (options.format !== undefined) raw.format = options.format;
+  if (options.verbose !== undefined) raw.verbose = options.verbose;
+  if (options.quiet !== undefined) raw.quiet = options.quiet;
+
+  const parsed = blockSchemaFor('diff').safeParse(raw);
+  if (!parsed.success) {
+    return { errors: formatZodIssues(parsed.error.issues, raw) };
+  }
+  return { cliOverrides: parsed.data as Partial<EffectiveOptions> };
+}

--- a/apps/cli/src/app/diff.command.ts
+++ b/apps/cli/src/app/diff.command.ts
@@ -1,28 +1,13 @@
 import { Logger } from '@nestjs/common';
 import { Parser, type Term } from 'n3';
 import { Command, CommandRunner, Option } from 'nest-commander';
-import {
-  canonicalizeRdf,
-  GRAPH_STRATEGIES,
-  isGraphStrategy,
-  type GraphStrategy,
-} from 'core';
+import { canonicalizeRdf, type GraphStrategy } from 'core';
 import { runWithConfig, type EffectiveOptions } from './config';
+import { DIFF_FORMATS, type DiffFormat } from './config/internal/schema';
+import { exitCodeFor, isAdapterFailure } from './cli-errors';
+import { diffAdapter, type DiffRawOptions } from './diff.adapter';
 
-const DIFF_FORMATS = ['human', 'json', 'rdf-patch'] as const;
-type DiffFormat = (typeof DIFF_FORMATS)[number];
-
-function isDiffFormat(value: string): value is DiffFormat {
-  return (DIFF_FORMATS as ReadonlyArray<string>).includes(value);
-}
-
-interface DiffOptions {
-  left?: string;
-  right?: string;
-  graphStrategy?: string;
-  format?: string;
-  verbose?: boolean;
-  quiet?: boolean;
+interface DiffOptions extends DiffRawOptions {
   config?: string;
   printConfig?: boolean;
 }
@@ -35,46 +20,22 @@ interface DiffOptions {
 })
 export class DiffCommand extends CommandRunner {
   async run(passedParams: string[], options: DiffOptions = {}): Promise<void> {
-    if (passedParams.length > 2) {
-      process.stderr.write(
-        `error: diff takes at most two positional arguments (got ${passedParams.length})\n`,
-      );
-      process.exitCode = 2;
+    const adapted = diffAdapter(passedParams, options);
+    if (isAdapterFailure(adapted)) {
+      for (const err of adapted.errors) {
+        process.stderr.write(`error: ${err.message}\n`);
+      }
+      process.exitCode = exitCodeFor('diff');
       return;
     }
 
-    const cliOverrides: Partial<EffectiveOptions> = {};
-    if (passedParams[0] !== undefined) cliOverrides.left = passedParams[0];
-    if (passedParams[1] !== undefined) cliOverrides.right = passedParams[1];
-    if (options.left !== undefined) cliOverrides.left = options.left;
-    if (options.right !== undefined) cliOverrides.right = options.right;
-    if (options.verbose !== undefined) cliOverrides.verbose = options.verbose;
-    if (options.quiet !== undefined) cliOverrides.quiet = options.quiet;
-
-    if (options.graphStrategy !== undefined) {
-      if (!isGraphStrategy(options.graphStrategy)) {
-        process.stderr.write(
-          `error: unknown --graph-strategy '${options.graphStrategy}' (expected ${GRAPH_STRATEGIES.join(', ')})\n`,
-        );
-        process.exitCode = 2;
-        return;
-      }
-      cliOverrides.graphStrategy = options.graphStrategy;
-    }
-
-    if (options.format !== undefined) {
-      if (!isDiffFormat(options.format)) {
-        process.stderr.write(
-          `error: unknown --format '${options.format}' (expected ${DIFF_FORMATS.join(', ')})\n`,
-        );
-        process.exitCode = 2;
-        return;
-      }
-      cliOverrides.format = options.format;
-    }
-
     await runWithConfig(
-      { command: 'diff', passedParams: [], options, cliOverrides },
+      {
+        command: 'diff',
+        passedParams: [],
+        options,
+        cliOverrides: adapted.cliOverrides,
+      },
       (effective) => this.execute(effective),
     );
   }
@@ -169,8 +130,7 @@ export class DiffCommand extends CommandRunner {
 
   @Option({
     flags: '-f, --format <format>',
-    description:
-      "Output format: 'human' (default; '+'/'-' lines), 'json' ({added,removed} object), or 'rdf-patch' (standard RDF Patch with A/D markers).",
+    description: `Output format: ${DIFF_FORMATS.map((f) => `'${f}'`).join(', ')}.`,
   })
   parseFormat(value: string): string {
     return value;

--- a/apps/cli/src/app/hash.adapter.spec.ts
+++ b/apps/cli/src/app/hash.adapter.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { isAdapterFailure } from './cli-errors';
+import { hashAdapter } from './hash.adapter';
+
+describe('hashAdapter', () => {
+  it('passes through repeated --sources as a string array', () => {
+    const result = hashAdapter([], {
+      sources: ['a/*.ttl', 'b/*.ttl'],
+      json: true,
+    });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.sources).toEqual(['a/*.ttl', 'b/*.ttl']);
+    expect(result.cliOverrides.json).toBe(true);
+  });
+
+  it('passes through --compare-with', () => {
+    const result = hashAdapter([], { compareWith: 'other/*.ttl' });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.compareWith).toBe('other/*.ttl');
+  });
+
+  it('rejects unknown --graph-strategy', () => {
+    const result = hashAdapter([], { graphStrategy: 'bogus' });
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0]).toEqual({
+      kind: 'unknown-flag',
+      message:
+        "unknown --graph-strategy 'bogus' (expected default, partial, full, none)",
+    });
+  });
+});

--- a/apps/cli/src/app/hash.adapter.ts
+++ b/apps/cli/src/app/hash.adapter.ts
@@ -1,0 +1,31 @@
+import { blockSchemaFor, type EffectiveOptions } from './config/internal/schema';
+import { formatZodIssues, type AdapterResult } from './cli-errors';
+
+export interface HashRawOptions {
+  sources?: string[];
+  graphStrategy?: string;
+  json?: boolean;
+  compareWith?: string;
+  verbose?: boolean;
+  quiet?: boolean;
+}
+
+export function hashAdapter(
+  _passedParams: string[],
+  options: HashRawOptions,
+): AdapterResult<Partial<EffectiveOptions>> {
+  const raw: Record<string, unknown> = {};
+  if (options.sources !== undefined) raw.sources = options.sources;
+  if (options.graphStrategy !== undefined)
+    raw.graphStrategy = options.graphStrategy;
+  if (options.json !== undefined) raw.json = options.json;
+  if (options.compareWith !== undefined) raw.compareWith = options.compareWith;
+  if (options.verbose !== undefined) raw.verbose = options.verbose;
+  if (options.quiet !== undefined) raw.quiet = options.quiet;
+
+  const parsed = blockSchemaFor('hash').safeParse(raw);
+  if (!parsed.success) {
+    return { errors: formatZodIssues(parsed.error.issues, raw) };
+  }
+  return { cliOverrides: parsed.data as Partial<EffectiveOptions> };
+}

--- a/apps/cli/src/app/hash.command.ts
+++ b/apps/cli/src/app/hash.command.ts
@@ -1,21 +1,12 @@
 import { createHash } from 'node:crypto';
 import { Logger } from '@nestjs/common';
 import { Command, CommandRunner, Option } from 'nest-commander';
-import {
-  canonicalizeRdf,
-  GRAPH_STRATEGIES,
-  isGraphStrategy,
-  type GraphStrategy,
-} from 'core';
+import { canonicalizeRdf, type GraphStrategy } from 'core';
 import { runWithConfig, type EffectiveOptions } from './config';
+import { exitCodeFor, isAdapterFailure } from './cli-errors';
+import { hashAdapter, type HashRawOptions } from './hash.adapter';
 
-interface HashOptions {
-  sources?: string[];
-  graphStrategy?: string;
-  json?: boolean;
-  compareWith?: string;
-  verbose?: boolean;
-  quiet?: boolean;
+interface HashOptions extends HashRawOptions {
   config?: string;
   printConfig?: boolean;
 }
@@ -28,29 +19,24 @@ interface HashOptions {
 })
 export class HashCommand extends CommandRunner {
   async run(passedParams: string[], options: HashOptions = {}): Promise<void> {
-    const cliOverrides: Partial<EffectiveOptions> = {};
-    if (options.sources !== undefined) cliOverrides.sources = options.sources;
-    if (options.json !== undefined) cliOverrides.json = options.json;
-    if (options.compareWith !== undefined)
-      cliOverrides.compareWith = options.compareWith;
-    if (options.verbose !== undefined) cliOverrides.verbose = options.verbose;
-    if (options.quiet !== undefined) cliOverrides.quiet = options.quiet;
-
-    const errorExit = options.compareWith !== undefined ? 2 : 1;
-
-    if (options.graphStrategy !== undefined) {
-      if (!isGraphStrategy(options.graphStrategy)) {
-        process.stderr.write(
-          `error: unknown --graph-strategy '${options.graphStrategy}' (expected ${GRAPH_STRATEGIES.join(', ')})\n`,
-        );
-        process.exitCode = errorExit;
-        return;
+    const adapted = hashAdapter(passedParams, options);
+    if (isAdapterFailure(adapted)) {
+      for (const err of adapted.errors) {
+        process.stderr.write(`error: ${err.message}\n`);
       }
-      cliOverrides.graphStrategy = options.graphStrategy;
+      process.exitCode = exitCodeFor('hash', {
+        hashCompareMode: options.compareWith !== undefined,
+      });
+      return;
     }
 
     await runWithConfig(
-      { command: 'hash', passedParams, options, cliOverrides },
+      {
+        command: 'hash',
+        passedParams,
+        options,
+        cliOverrides: adapted.cliOverrides,
+      },
       (effective) => this.execute(effective),
     );
   }

--- a/apps/cli/src/app/query.adapter.spec.ts
+++ b/apps/cli/src/app/query.adapter.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { isAdapterFailure } from './cli-errors';
+import { queryAdapter } from './query.adapter';
+
+describe('queryAdapter', () => {
+  it('passes through valid options as cliOverrides', () => {
+    const result = queryAdapter([], {
+      sources: 'data/*.ttl',
+      query: 'SELECT ?s WHERE { ?s ?p ?o }',
+      format: 'turtle',
+      graphStrategy: 'partial',
+      verbose: true,
+    });
+
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides).toEqual({
+      sources: 'data/*.ttl',
+      query: 'SELECT ?s WHERE { ?s ?p ?o }',
+      format: 'turtle',
+      graphStrategy: 'partial',
+      verbose: true,
+    });
+  });
+
+  it('rejects an unknown --format with the canonical phrasing', () => {
+    const result = queryAdapter([], { format: 'csv' });
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0].kind).toBe('unknown-flag');
+    expect(result.errors[0].message).toBe(
+      "unknown --format 'csv' (expected json, turtle)",
+    );
+  });
+
+  it('--mutable maps to mutable: true', () => {
+    const result = queryAdapter([], { mutable: true });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.mutable).toBe(true);
+  });
+
+  it('--immutable=false maps to mutable: true', () => {
+    const result = queryAdapter([], { immutable: false });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.mutable).toBe(true);
+  });
+
+  it('--immutable=true (or bare --immutable) maps to mutable: false', () => {
+    const result = queryAdapter([], { immutable: true });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.mutable).toBe(false);
+  });
+
+  it('omits mutable when neither --mutable nor --immutable is given', () => {
+    const result = queryAdapter([], { query: 'SELECT ?s WHERE { ?s ?p ?o }' });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect('mutable' in result.cliOverrides).toBe(false);
+  });
+
+  it('rejects an unknown --graph-strategy with the canonical phrasing', () => {
+    const result = queryAdapter([], { graphStrategy: 'bogus' });
+
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].kind).toBe('unknown-flag');
+    expect(result.errors[0].message).toBe(
+      "unknown --graph-strategy 'bogus' (expected default, partial, full, none)",
+    );
+  });
+});

--- a/apps/cli/src/app/query.adapter.ts
+++ b/apps/cli/src/app/query.adapter.ts
@@ -1,0 +1,42 @@
+import { blockSchemaFor, type EffectiveOptions } from './config/internal/schema';
+import {
+  formatZodIssues,
+  mutableFromCli,
+  type AdapterResult,
+} from './cli-errors';
+
+export interface QueryRawOptions {
+  sources?: string;
+  query?: string;
+  queryFile?: string;
+  format?: string;
+  graphStrategy?: string;
+  mutable?: boolean;
+  immutable?: boolean;
+  verbose?: boolean;
+  quiet?: boolean;
+}
+
+export function queryAdapter(
+  _passedParams: string[],
+  options: QueryRawOptions,
+): AdapterResult<Partial<EffectiveOptions>> {
+  const raw: Record<string, unknown> = {};
+  if (options.sources !== undefined) raw.sources = options.sources;
+  if (options.query !== undefined) raw.query = options.query;
+  if (options.queryFile !== undefined) raw.queryFile = options.queryFile;
+  if (options.format !== undefined) raw.format = options.format;
+  if (options.graphStrategy !== undefined)
+    raw.graphStrategy = options.graphStrategy;
+  if (options.verbose !== undefined) raw.verbose = options.verbose;
+  if (options.quiet !== undefined) raw.quiet = options.quiet;
+  const mutable = mutableFromCli(options);
+  if (mutable !== undefined) raw.mutable = mutable;
+
+  const parsed = blockSchemaFor('query').safeParse(raw);
+  if (!parsed.success) {
+    return { errors: formatZodIssues(parsed.error.issues, raw) };
+  }
+
+  return { cliOverrides: parsed.data as Partial<EffectiveOptions> };
+}

--- a/apps/cli/src/app/query.command.ts
+++ b/apps/cli/src/app/query.command.ts
@@ -2,26 +2,16 @@ import { readFile } from 'node:fs/promises';
 import { Logger } from '@nestjs/common';
 import { Command, CommandRunner, Option } from 'nest-commander';
 import {
-  GRAPH_STRATEGIES,
   QueryEngine,
-  isGraphStrategy,
-  isSparqlFormat,
   loadRdf,
   type GraphStrategy,
   type SparqlFormat,
 } from 'core';
 import { runWithConfig, type EffectiveOptions } from './config';
+import { exitCodeFor, isAdapterFailure } from './cli-errors';
+import { queryAdapter, type QueryRawOptions } from './query.adapter';
 
-interface QueryOptions {
-  sources?: string;
-  query?: string;
-  queryFile?: string;
-  format?: string;
-  graphStrategy?: string;
-  mutable?: boolean;
-  immutable?: boolean;
-  verbose?: boolean;
-  quiet?: boolean;
+interface QueryOptions extends QueryRawOptions {
   config?: string;
   printConfig?: boolean;
 }
@@ -33,39 +23,22 @@ interface QueryOptions {
 })
 export class QueryCommand extends CommandRunner {
   async run(passedParams: string[], options: QueryOptions = {}): Promise<void> {
-    const cliOverrides: Partial<EffectiveOptions> = {};
-    if (options.sources !== undefined) cliOverrides.sources = options.sources;
-    if (options.query !== undefined) cliOverrides.query = options.query;
-    if (options.queryFile !== undefined)
-      cliOverrides.queryFile = options.queryFile;
-    if (options.verbose !== undefined) cliOverrides.verbose = options.verbose;
-    if (options.quiet !== undefined) cliOverrides.quiet = options.quiet;
-
-    if (options.format !== undefined) {
-      if (!isSparqlFormat(options.format)) {
-        process.stderr.write(
-          `error: unknown --format '${options.format}' (expected 'json' or 'turtle')\n`,
-        );
-        process.exitCode = 1;
-        return;
+    const adapted = queryAdapter(passedParams, options);
+    if (isAdapterFailure(adapted)) {
+      for (const err of adapted.errors) {
+        process.stderr.write(`error: ${err.message}\n`);
       }
-      cliOverrides.format = options.format;
+      process.exitCode = exitCodeFor('query');
+      return;
     }
-    if (options.graphStrategy !== undefined) {
-      if (!isGraphStrategy(options.graphStrategy)) {
-        process.stderr.write(
-          `error: unknown --graph-strategy '${options.graphStrategy}' (expected ${GRAPH_STRATEGIES.join(', ')})\n`,
-        );
-        process.exitCode = 1;
-        return;
-      }
-      cliOverrides.graphStrategy = options.graphStrategy;
-    }
-    const cliMutable = mutableFromCli(options);
-    if (cliMutable !== undefined) cliOverrides.mutable = cliMutable;
 
     await runWithConfig(
-      { command: 'query', passedParams, options, cliOverrides },
+      {
+        command: 'query',
+        passedParams,
+        options,
+        cliOverrides: adapted.cliOverrides,
+      },
       (effective) => this.execute(effective),
     );
   }
@@ -117,7 +90,7 @@ export class QueryCommand extends CommandRunner {
 
     const graphStrategy: GraphStrategy | undefined = effective.graphStrategy;
     const format =
-      effective.format !== undefined && isSparqlFormat(effective.format)
+      effective.format === 'json' || effective.format === 'turtle'
         ? (effective.format as SparqlFormat)
         : undefined;
     const mutable = effective.mutable === true;
@@ -244,13 +217,4 @@ export class QueryCommand extends CommandRunner {
   parsePrintConfig(): boolean {
     return true;
   }
-}
-
-export function mutableFromCli(options: {
-  mutable?: boolean;
-  immutable?: boolean;
-}): boolean | undefined {
-  if (options.mutable === true) return true;
-  if (options.immutable !== undefined) return options.immutable === false;
-  return undefined;
 }

--- a/apps/cli/src/app/serve.adapter.spec.ts
+++ b/apps/cli/src/app/serve.adapter.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isAdapterFailure } from './cli-errors';
+import { serveAdapter } from './serve.adapter';
+
+describe('serveAdapter', () => {
+  it('passes through valid options as cliOverrides (with coerced port)', () => {
+    const result = serveAdapter([], {
+      sources: 'data/*.ttl',
+      port: 4000,
+      graphStrategy: 'full',
+      watch: true,
+      watchDebounce: 500,
+    });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides).toEqual({
+      sources: 'data/*.ttl',
+      port: 4000,
+      graphStrategy: 'full',
+      watch: true,
+      watchDebounce: 500,
+    });
+  });
+
+  it('rejects unknown --graph-strategy', () => {
+    const result = serveAdapter([], { graphStrategy: 'bogus' });
+    if (!isAdapterFailure(result)) throw new Error('expected error');
+    expect(result.errors[0]).toEqual({
+      kind: 'unknown-flag',
+      message:
+        "unknown --graph-strategy 'bogus' (expected default, partial, full, none)",
+    });
+  });
+
+  it('--immutable=false produces mutable: true', () => {
+    const result = serveAdapter([], { immutable: false });
+    if (isAdapterFailure(result)) throw new Error('expected ok');
+    expect(result.cliOverrides.mutable).toBe(true);
+  });
+});

--- a/apps/cli/src/app/serve.adapter.ts
+++ b/apps/cli/src/app/serve.adapter.ts
@@ -1,0 +1,42 @@
+import { blockSchemaFor, type EffectiveOptions } from './config/internal/schema';
+import {
+  formatZodIssues,
+  mutableFromCli,
+  type AdapterResult,
+} from './cli-errors';
+
+export interface ServeRawOptions {
+  sources?: string;
+  port?: number;
+  graphStrategy?: string;
+  mutable?: boolean;
+  immutable?: boolean;
+  verbose?: boolean;
+  quiet?: boolean;
+  watch?: boolean;
+  watchDebounce?: number;
+}
+
+export function serveAdapter(
+  _passedParams: string[],
+  options: ServeRawOptions,
+): AdapterResult<Partial<EffectiveOptions>> {
+  const raw: Record<string, unknown> = {};
+  if (options.sources !== undefined) raw.sources = options.sources;
+  if (options.port !== undefined) raw.port = options.port;
+  if (options.graphStrategy !== undefined)
+    raw.graphStrategy = options.graphStrategy;
+  if (options.watch !== undefined) raw.watch = options.watch;
+  if (options.watchDebounce !== undefined)
+    raw.watchDebounce = options.watchDebounce;
+  if (options.verbose !== undefined) raw.verbose = options.verbose;
+  if (options.quiet !== undefined) raw.quiet = options.quiet;
+  const mutable = mutableFromCli(options);
+  if (mutable !== undefined) raw.mutable = mutable;
+
+  const parsed = blockSchemaFor('serve').safeParse(raw);
+  if (!parsed.success) {
+    return { errors: formatZodIssues(parsed.error.issues, raw) };
+  }
+  return { cliOverrides: parsed.data as Partial<EffectiveOptions> };
+}

--- a/apps/cli/src/app/serve.command.ts
+++ b/apps/cli/src/app/serve.command.ts
@@ -1,26 +1,14 @@
 import { join } from 'node:path';
 import { Command, CommandRunner, Option } from 'nest-commander';
-import {
-  GRAPH_STRATEGIES,
-  isGraphStrategy,
-  type GraphStrategy,
-} from 'core';
+import { type GraphStrategy } from 'core';
 import { createServer } from 'server';
 import { runWithConfig, type EffectiveOptions } from './config';
-import { mutableFromCli } from './query.command';
+import { exitCodeFor, isAdapterFailure } from './cli-errors';
+import { serveAdapter, type ServeRawOptions } from './serve.adapter';
 
 const WEB_BUNDLE_DIR = join(__dirname, 'web');
 
-interface ServeOptions {
-  sources?: string;
-  port?: number;
-  graphStrategy?: string;
-  mutable?: boolean;
-  immutable?: boolean;
-  verbose?: boolean;
-  quiet?: boolean;
-  watch?: boolean;
-  watchDebounce?: number;
+interface ServeOptions extends ServeRawOptions {
   config?: string;
   printConfig?: boolean;
 }
@@ -32,30 +20,22 @@ interface ServeOptions {
 })
 export class ServeCommand extends CommandRunner {
   async run(passedParams: string[], options: ServeOptions = {}): Promise<void> {
-    const cliOverrides: Partial<EffectiveOptions> = {};
-    if (options.sources !== undefined) cliOverrides.sources = options.sources;
-    if (options.port !== undefined) cliOverrides.port = options.port;
-    if (options.watch !== undefined) cliOverrides.watch = options.watch;
-    if (options.watchDebounce !== undefined)
-      cliOverrides.watchDebounce = options.watchDebounce;
-    if (options.verbose !== undefined) cliOverrides.verbose = options.verbose;
-    if (options.quiet !== undefined) cliOverrides.quiet = options.quiet;
-
-    if (options.graphStrategy !== undefined) {
-      if (!isGraphStrategy(options.graphStrategy)) {
-        process.stderr.write(
-          `error: unknown --graph-strategy '${options.graphStrategy}' (expected ${GRAPH_STRATEGIES.join(', ')})\n`,
-        );
-        process.exitCode = 1;
-        return;
+    const adapted = serveAdapter(passedParams, options);
+    if (isAdapterFailure(adapted)) {
+      for (const err of adapted.errors) {
+        process.stderr.write(`error: ${err.message}\n`);
       }
-      cliOverrides.graphStrategy = options.graphStrategy;
+      process.exitCode = exitCodeFor('serve');
+      return;
     }
-    const cliMutable = mutableFromCli(options);
-    if (cliMutable !== undefined) cliOverrides.mutable = cliMutable;
 
     await runWithConfig(
-      { command: 'serve', passedParams, options, cliOverrides },
+      {
+        command: 'serve',
+        passedParams,
+        options,
+        cliOverrides: adapted.cliOverrides,
+      },
       (effective) => this.execute(effective),
     );
   }

--- a/libs/core/src/lib/query-engine.ts
+++ b/libs/core/src/lib/query-engine.ts
@@ -2,14 +2,14 @@ import { QueryEngine as ComunicaQueryEngine } from '@comunica/query-sparql';
 import type { Store } from 'n3';
 import { assertImmutable, detectQueryType } from './immutability';
 
-export type SparqlFormat = 'json' | 'turtle';
+export const SUPPORTED_FORMATS = ['json', 'turtle'] as const;
+
+export type SparqlFormat = (typeof SUPPORTED_FORMATS)[number];
 
 const FORMAT_TO_MIME: Record<SparqlFormat, string> = {
   json: 'application/sparql-results+json',
   turtle: 'text/turtle',
 };
-
-const SUPPORTED_FORMATS: ReadonlyArray<SparqlFormat> = ['json', 'turtle'];
 
 export interface ExecuteOptions {
   format?: SparqlFormat;
@@ -20,10 +20,6 @@ export interface ExecuteResult {
   body: string;
   format: SparqlFormat;
   contentType: string;
-}
-
-export function isSparqlFormat(value: string): value is SparqlFormat {
-  return (SUPPORTED_FORMATS as ReadonlyArray<string>).includes(value);
 }
 
 export type StoreSource = Store | (() => Store);

--- a/libs/core/src/lib/rdf-loader.ts
+++ b/libs/core/src/lib/rdf-loader.ts
@@ -4,18 +4,14 @@ import { DataFactory, Store, type DefaultGraph, type NamedNode, type Quad } from
 import { rdfParser } from 'rdf-parse';
 import { glob } from 'tinyglobby';
 
-export type GraphStrategy = 'default' | 'partial' | 'full' | 'none';
-
-export const GRAPH_STRATEGIES: ReadonlyArray<GraphStrategy> = [
+export const GRAPH_STRATEGIES = [
   'default',
   'partial',
   'full',
   'none',
-];
+] as const;
 
-export function isGraphStrategy(value: string): value is GraphStrategy {
-  return (GRAPH_STRATEGIES as ReadonlyArray<string>).includes(value);
-}
+export type GraphStrategy = (typeof GRAPH_STRATEGIES)[number];
 
 export interface LoadOptions {
   sources: string | string[];


### PR DESCRIPTION
Closes #42.

## Summary
- New per-command adapters (`apps/cli/src/app/{query,serve,hash,diff}.adapter.ts`) that own the raw-options → `cliOverrides` translation and parse through the existing Zod block schemas. Each `run()` collapses to a thin glue layer: call the adapter, write structured errors, set the right exit code, then `runWithConfig`.
- New `apps/cli/src/app/cli-errors.ts`: Zod-issue → CLI-message formatter (preserves the canonical `error: unknown --<flag> '<v>' (expected <list>)` phrasing), `exitCodeFor` mapper (incl. hash compare-mode), `mutableFromCli` (shared between query and serve adapters), and the `isAdapterFailure` guard.
- `core` exposes `GRAPH_STRATEGIES` and `SUPPORTED_FORMATS` as `as const` tuples; `GraphStrategy` / `SparqlFormat` are derived. Hand-rolled `isGraphStrategy` / `isSparqlFormat` predicates removed.
- `apps/cli/src/app/config/internal/schema.ts` now consumes the core tuples via `z.enum(GRAPH_STRATEGIES)` / `z.enum(SUPPORTED_FORMATS)`; `DIFF_FORMATS` (CLI-local) lives here too.

## Design notes
- Adapter return shape is `{ cliOverrides } | { errors }` (the literal shape from the ADR), narrowed via `isAdapterFailure`. Without `strict` in the cli tsconfig, an `ok: true | false` discriminant doesn't narrow at build time, while `'errors' in r` does.
- `query.command.ts` no longer needs `isSparqlFormat` inside `execute` — the adapter validated the value, so a narrow inline check is enough.

## Test plan
- [x] `nx test cli` — 127 passed (109 existing integration tests + 28 new adapter / cli-errors unit tests covering valid input, unknown-flag cases, missing-required cases, hash repeated `--sources`, hash `--compare-with`, diff two-positional cap, mutable / immutable matrix, exit-code matrix).
- [x] `nx build cli` — succeeds.
- [x] `nx run-many -t lint test --projects=cli,core,server,domain` — clean.
- [x] No behavioral change observable from the outside: same stderr phrasing, same exit codes (verified by the unmodified command spec suite).