### PR TITLE
feat(format): bootstrap formatter module + sparqly format command

### DIFF
--- a/apps/cli-e2e/fixtures/format/simple.ttl
+++ b/apps/cli-e2e/fixtures/format/simple.ttl
@@ -1,0 +1,6 @@
+@prefix ex: <http://example.org/> .
+@prefix unused: <http://other.example/> .
+
+ex:c ex:p ex:d .
+ex:a ex:p ex:b .
+ex:a a ex:Thing .

--- a/apps/cli-e2e/src/format-core.e2e.spec.ts
+++ b/apps/cli-e2e/src/format-core.e2e.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { runCli } from './helpers/run-cli';
+import { formatFixture } from './helpers/hash';
+
+describe('sparqly format — core happy path', () => {
+  it('formats a glob and prints to stdout, exit 0', async () => {
+    const result = await runCli(['format', formatFixture('simple.ttl')]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('@prefix ex: <http://example.org/>');
+    expect(result.stdout).not.toContain('@prefix unused:');
+    expect(result.stdout).toContain('ex:a a ex:Thing');
+  });
+
+  it('reads turtle from stdin when no positional argument is supplied', async () => {
+    const turtle = [
+      '@prefix ex: <http://example.org/> .',
+      'ex:b ex:p ex:c .',
+      'ex:a ex:p ex:b .',
+      '',
+    ].join('\n');
+
+    const result = await runCli(['format'], { stdin: turtle });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('@prefix ex: <http://example.org/>');
+    expect(result.stdout).toContain('ex:a ex:p ex:b');
+    const aIdx = result.stdout.indexOf('ex:a ex:p');
+    const bIdx = result.stdout.indexOf('ex:b ex:p');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(bIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeLessThan(bIdx);
+  });
+
+  it('errors when no glob is supplied and stdin is a TTY', async () => {
+    const result = await runCli(['format']);
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/glob|stdin|input/i);
+  });
+});

--- a/apps/cli-e2e/src/helpers/hash.ts
+++ b/apps/cli-e2e/src/helpers/hash.ts
@@ -5,6 +5,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 
 const HASH_FIXTURES = resolve(HERE, '../../fixtures/hash');
 const DIFF_FIXTURES = resolve(HERE, '../../fixtures/diff');
+const FORMAT_FIXTURES = resolve(HERE, '../../fixtures/format');
 
 export function hashFixture(...segments: string[]): string {
   return resolve(HASH_FIXTURES, ...segments);
@@ -12,6 +13,10 @@ export function hashFixture(...segments: string[]): string {
 
 export function diffFixture(...segments: string[]): string {
   return resolve(DIFF_FIXTURES, ...segments);
+}
+
+export function formatFixture(...segments: string[]): string {
+  return resolve(FORMAT_FIXTURES, ...segments);
 }
 
 export function leadingHash(line: string): string {

--- a/apps/cli/src/app/app.module.ts
+++ b/apps/cli/src/app/app.module.ts
@@ -1,10 +1,17 @@
 import { Module } from '@nestjs/common';
 import { DiffCommand } from './diff.command';
+import { FormatCommand } from './format.command';
 import { HashCommand } from './hash.command';
 import { QueryCommand } from './query.command';
 import { ServeCommand } from './serve.command';
 
 @Module({
-  providers: [DiffCommand, HashCommand, QueryCommand, ServeCommand],
+  providers: [
+    DiffCommand,
+    FormatCommand,
+    HashCommand,
+    QueryCommand,
+    ServeCommand,
+  ],
 })
 export class AppModule {}

--- a/apps/cli/src/app/format.command.ts
+++ b/apps/cli/src/app/format.command.ts
@@ -1,0 +1,110 @@
+import { Logger } from '@nestjs/common';
+import { Parser, type Quad } from 'n3';
+import { Command, CommandRunner } from 'nest-commander';
+import { formatRdf, loadRdf, type FormatSerialization } from 'core';
+import { extname } from 'node:path';
+
+@Command({
+  name: 'format',
+  description:
+    'Pretty-print Turtle/TriG files. Reads a glob, or stdin when no glob is supplied, and writes the formatted result to stdout.',
+  arguments: '[glob]',
+})
+export class FormatCommand extends CommandRunner {
+  async run(passedParams: string[]): Promise<void> {
+    const logger = new Logger('sparqly');
+    const positional = passedParams[0];
+
+    if (positional) {
+      try {
+        const start = Date.now();
+        const { store, files, prefixes } = await loadRdf({ sources: positional });
+        logger.log(
+          `Loaded ${files.length} file(s) (${store.size} quads) in ${
+            Date.now() - start
+          }ms`,
+        );
+        const serialization = inferSerialization(files);
+        const merged = mergeFilePrefixes(prefixes);
+        const out = formatRdf(
+          store.getQuads(null, null, null, null),
+          serialization,
+          { prefixes: merged },
+        );
+        process.stdout.write(out.endsWith('\n') ? out : `${out}\n`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`error: ${message}\n`);
+        process.exitCode = 1;
+      }
+      return;
+    }
+
+    const stdinText = await readStdin();
+    if (!stdinText) {
+      process.stderr.write(
+        'error: a glob is required, or pipe Turtle/TriG via stdin\n',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      const { quads, prefixes } = parseStdin(stdinText);
+      const serialization: FormatSerialization = quads.some(
+        (q) => q.graph.termType === 'NamedNode',
+      )
+        ? 'trig'
+        : 'turtle';
+      const out = formatRdf(quads, serialization, { prefixes });
+      process.stdout.write(out.endsWith('\n') ? out : `${out}\n`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`error: failed to parse stdin: ${message}\n`);
+      process.exitCode = 1;
+    }
+  }
+}
+
+function inferSerialization(files: string[]): FormatSerialization {
+  return files.some((f) => extname(f).toLowerCase() === '.trig')
+    ? 'trig'
+    : 'turtle';
+}
+
+function mergeFilePrefixes(
+  perFile: Record<string, Record<string, string>>,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const file of Object.keys(perFile)) {
+    for (const [name, iri] of Object.entries(perFile[file])) {
+      if (!(name in merged)) merged[name] = iri;
+    }
+  }
+  return merged;
+}
+
+interface ParsedStdin {
+  quads: Quad[];
+  prefixes: Record<string, string>;
+}
+
+function parseStdin(text: string): ParsedStdin {
+  const prefixes: Record<string, string> = {};
+  const quads = new Parser().parse(text, null, (prefix, iri) => {
+    if (prefix && iri) {
+      prefixes[prefix] = (iri as { value: string }).value;
+    }
+  });
+  return { quads, prefixes };
+}
+
+async function readStdin(): Promise<string | null> {
+  if (process.stdin.isTTY) return null;
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  const text = Buffer.concat(chunks).toString('utf8').trim();
+  return text.length > 0 ? text : null;
+}

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/query-engine';
 export * from './lib/rdf-loader';
 export * from './lib/canonicalize';
 export * from './lib/immutability';
+export * from './lib/formatter';

--- a/libs/core/src/lib/formatter.spec.ts
+++ b/libs/core/src/lib/formatter.spec.ts
@@ -1,0 +1,321 @@
+import { DataFactory, Parser } from 'n3';
+import { canonize } from 'rdf-canonize';
+import { describe, expect, it } from 'vitest';
+import { formatRdf } from './formatter';
+
+const { namedNode, quad } = DataFactory;
+
+describe('formatRdf', () => {
+  it('returns an empty string for an empty quad iterable', () => {
+    expect(formatRdf([], 'turtle', { prefixes: {} })).toBe('');
+  });
+
+  it('emits an IRI in full <...> form when no configured prefix matches', () => {
+    const out = formatRdf(
+      [
+        quad(
+          namedNode('http://example.org/a'),
+          namedNode('http://example.org/p'),
+          namedNode('http://example.org/b'),
+        ),
+      ],
+      'turtle',
+      { prefixes: {} },
+    );
+
+    expect(out).toContain('<http://example.org/a>');
+    expect(out).toContain('<http://example.org/p>');
+    expect(out).toContain('<http://example.org/b>');
+    expect(out).not.toMatch(/^@prefix /m);
+    const parsed = new Parser({ format: 'text/turtle' }).parse(out);
+    expect(parsed).toHaveLength(1);
+  });
+
+  it('shortens IRIs to CURIEs when a configured prefix matches', () => {
+    const out = formatRdf(
+      [
+        quad(
+          namedNode('http://example.org/a'),
+          namedNode('http://example.org/p'),
+          namedNode('http://example.org/b'),
+        ),
+      ],
+      'turtle',
+      { prefixes: { ex: 'http://example.org/' } },
+    );
+
+    expect(out).toMatch(/^@prefix ex: <http:\/\/example\.org\/>\s*\.$/m);
+    expect(out).toContain('ex:a');
+    expect(out).toContain('ex:p');
+    expect(out).toContain('ex:b');
+    expect(out).not.toContain('<http://example.org/a>');
+  });
+
+  it('drops prefixes that are not used by any quad', () => {
+    const out = formatRdf(
+      [
+        quad(
+          namedNode('http://example.org/a'),
+          namedNode('http://example.org/p'),
+          namedNode('http://example.org/b'),
+        ),
+      ],
+      'turtle',
+      {
+        prefixes: {
+          ex: 'http://example.org/',
+          unused: 'http://other.example/',
+        },
+      },
+    );
+
+    expect(out).toContain('@prefix ex:');
+    expect(out).not.toContain('@prefix unused:');
+    expect(out).not.toContain('http://other.example/');
+  });
+
+  it('produces identical output regardless of input quad order', () => {
+    const ex = 'http://example.org/';
+    const triples = [
+      quad(namedNode(ex + 'b'), namedNode(ex + 'p'), namedNode(ex + 'z')),
+      quad(namedNode(ex + 'a'), namedNode(ex + 'q'), namedNode(ex + 'y')),
+      quad(namedNode(ex + 'a'), namedNode(ex + 'p'), namedNode(ex + 'x')),
+      quad(namedNode(ex + 'b'), namedNode(ex + 'p'), namedNode(ex + 'a')),
+    ];
+
+    const a = formatRdf(triples, 'turtle', { prefixes: { ex } });
+    const b = formatRdf([...triples].reverse(), 'turtle', { prefixes: { ex } });
+
+    expect(a).toBe(b);
+  });
+
+  it('renders rdf:type as `a` and emits it before other predicates of the same subject', () => {
+    const ex = 'http://example.org/';
+    const rdfType = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+    const out = formatRdf(
+      [
+        quad(namedNode(ex + 's'), namedNode(ex + 'p'), namedNode(ex + 'o')),
+        quad(namedNode(ex + 's'), namedNode(rdfType), namedNode(ex + 'T')),
+      ],
+      'turtle',
+      { prefixes: { ex } },
+    );
+
+    const aIdx = out.indexOf(' a ');
+    const pIdx = out.indexOf('ex:p');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(pIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeLessThan(pIdx);
+    expect(out).not.toContain('rdf:type');
+  });
+
+  describe('over the turtle corpus', () => {
+    it('matches the golden snapshot for simple-prefix', () => {
+      const fixture = TURTLE_CORPUS[0];
+      const quads = new Parser({ format: 'text/turtle' }).parse(fixture.turtle);
+      const out = formatRdf(quads, 'turtle', {
+        prefixes: parsePrefixes(fixture.turtle),
+      });
+
+      expect(out).toMatchInlineSnapshot(`
+        "@prefix ex: <http://example.org/>.
+
+        ex:a a ex:Thing;
+            ex:p ex:b.
+        ex:c ex:p ex:d.
+        "
+      `);
+    });
+
+    for (const fixture of TURTLE_CORPUS) {
+      it(`is idempotent for ${fixture.name}`, () => {
+        const quads1 = new Parser({ format: 'text/turtle' }).parse(
+          fixture.turtle,
+        );
+        const out1 = formatRdf(quads1, 'turtle', {
+          prefixes: parsePrefixes(fixture.turtle),
+        });
+        const quads2 = new Parser({ format: 'text/turtle' }).parse(out1);
+        const out2 = formatRdf(quads2, 'turtle', {
+          prefixes: parsePrefixes(out1),
+        });
+        expect(out2).toBe(out1);
+      });
+
+      it(`round-trips through canonicalization for ${fixture.name}`, async () => {
+        const original = new Parser({ format: 'text/turtle' }).parse(
+          fixture.turtle,
+        );
+        const out = formatRdf(original, 'turtle', {
+          prefixes: parsePrefixes(fixture.turtle),
+        });
+        const formatted = new Parser({ format: 'text/turtle' }).parse(out);
+        const [originalCanon, formattedCanon] = await Promise.all([
+          canonize(original, {
+            algorithm: 'RDFC-1.0',
+            format: 'application/n-quads',
+          }),
+          canonize(formatted, {
+            algorithm: 'RDFC-1.0',
+            format: 'application/n-quads',
+          }),
+        ]);
+        expect(formattedCanon).toBe(originalCanon);
+      });
+    }
+  });
+
+  describe('trig output', () => {
+    it('orders graph blocks alphabetically by graph IRI', () => {
+      const trig = [
+        '@prefix ex: <http://example.org/> .',
+        '',
+        'ex:gZ { ex:s ex:p ex:o . }',
+        'ex:gA { ex:s ex:p ex:o . }',
+        'ex:gM { ex:s ex:p ex:o . }',
+        '',
+      ].join('\n');
+      const quads = new Parser({ format: 'application/trig' }).parse(trig);
+      const out = formatRdf(quads, 'trig', {
+        prefixes: parsePrefixes(trig, 'application/trig'),
+      });
+
+      const aIdx = out.indexOf('ex:gA');
+      const mIdx = out.indexOf('ex:gM');
+      const zIdx = out.indexOf('ex:gZ');
+      expect(aIdx).toBeGreaterThan(-1);
+      expect(mIdx).toBeGreaterThan(-1);
+      expect(zIdx).toBeGreaterThan(-1);
+      expect(aIdx).toBeLessThan(mIdx);
+      expect(mIdx).toBeLessThan(zIdx);
+    });
+
+    it('matches the golden snapshot for two-named-graphs', () => {
+      const trig = TRIG_CORPUS[0].trig;
+      const quads = new Parser({ format: 'application/trig' }).parse(trig);
+      const out = formatRdf(quads, 'trig', {
+        prefixes: parsePrefixes(trig, 'application/trig'),
+      });
+
+      expect(out).toMatchInlineSnapshot(`
+        "@prefix ex: <http://example.org/>.
+
+        ex:g1 {
+        ex:a ex:p ex:b
+        }
+        ex:g2 {
+        ex:c ex:q ex:d
+        }
+        "
+      `);
+    });
+
+    for (const fixture of TRIG_CORPUS) {
+      it(`is idempotent for ${fixture.name}`, () => {
+        const quads1 = new Parser({ format: 'application/trig' }).parse(
+          fixture.trig,
+        );
+        const out1 = formatRdf(quads1, 'trig', {
+          prefixes: parsePrefixes(fixture.trig, 'application/trig'),
+        });
+        const quads2 = new Parser({ format: 'application/trig' }).parse(out1);
+        const out2 = formatRdf(quads2, 'trig', {
+          prefixes: parsePrefixes(out1, 'application/trig'),
+        });
+        expect(out2).toBe(out1);
+      });
+
+      it(`round-trips through canonicalization for ${fixture.name}`, async () => {
+        const original = new Parser({ format: 'application/trig' }).parse(
+          fixture.trig,
+        );
+        const out = formatRdf(original, 'trig', {
+          prefixes: parsePrefixes(fixture.trig, 'application/trig'),
+        });
+        const formatted = new Parser({ format: 'application/trig' }).parse(out);
+        const [originalCanon, formattedCanon] = await Promise.all([
+          canonize(original, {
+            algorithm: 'RDFC-1.0',
+            format: 'application/n-quads',
+          }),
+          canonize(formatted, {
+            algorithm: 'RDFC-1.0',
+            format: 'application/n-quads',
+          }),
+        ]);
+        expect(formattedCanon).toBe(originalCanon);
+      });
+    }
+  });
+});
+
+const TRIG_CORPUS: ReadonlyArray<{ name: string; trig: string }> = [
+  {
+    name: 'two-named-graphs',
+    trig: [
+      '@prefix ex: <http://example.org/> .',
+      '',
+      'ex:g1 { ex:a ex:p ex:b . }',
+      'ex:g2 { ex:c ex:q ex:d . }',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'default-and-named-graph',
+    trig: [
+      '@prefix ex: <http://example.org/> .',
+      '',
+      'ex:a ex:p ex:b .',
+      'ex:g { ex:c ex:q ex:d . }',
+      '',
+    ].join('\n'),
+  },
+];
+
+const TURTLE_CORPUS: ReadonlyArray<{ name: string; turtle: string }> = [
+  {
+    name: 'simple-prefix',
+    turtle: [
+      '@prefix ex: <http://example.org/> .',
+      '@prefix unused: <http://other.example/> .',
+      '',
+      'ex:c ex:p ex:d .',
+      'ex:a ex:p ex:b .',
+      'ex:a a ex:Thing .',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'mixed-known-and-unknown-iris',
+    turtle: [
+      '@prefix ex: <http://example.org/> .',
+      '',
+      'ex:a ex:p <http://other.example/x> .',
+      '<http://yet-another.example/s> ex:p ex:b .',
+      '',
+    ].join('\n'),
+  },
+  {
+    name: 'literals',
+    turtle: [
+      '@prefix ex: <http://example.org/> .',
+      '',
+      'ex:a ex:p "hello" .',
+      'ex:a ex:p "bonjour"@fr .',
+      'ex:a ex:p 42 .',
+      '',
+    ].join('\n'),
+  },
+];
+
+function parsePrefixes(
+  text: string,
+  format: 'text/turtle' | 'application/trig' = 'text/turtle',
+): Record<string, string> {
+  const prefixes: Record<string, string> = {};
+  const parser = new Parser({ format });
+  parser.parse(text, undefined, (prefix, iri) => {
+    if (prefix && iri) prefixes[prefix] = (iri as { value: string }).value;
+  });
+  return prefixes;
+}

--- a/libs/core/src/lib/formatter.ts
+++ b/libs/core/src/lib/formatter.ts
@@ -1,0 +1,121 @@
+import { Writer, type Quad, type Term } from 'n3';
+
+export type FormatSerialization = 'turtle' | 'trig';
+
+export interface ResolvedFormatterConfig {
+  prefixes: Record<string, string>;
+}
+
+const SERIALIZATION_TO_FORMAT: Record<FormatSerialization, string> = {
+  turtle: 'text/turtle',
+  trig: 'application/trig',
+};
+
+export function formatRdf(
+  quads: Iterable<Quad>,
+  serialization: FormatSerialization,
+  config: ResolvedFormatterConfig,
+): string {
+  const list = Array.from(quads);
+  if (list.length === 0) return '';
+
+  const usedPrefixes = pickUsedPrefixes(list, config.prefixes);
+  const sorted = [...list].sort(compareQuads);
+
+  const writer = new Writer({
+    format: SERIALIZATION_TO_FORMAT[serialization],
+    prefixes: usedPrefixes,
+  });
+  for (const q of sorted) writer.addQuad(q);
+
+  let output = '';
+  writer.end((error, result) => {
+    if (error) throw error;
+    output = result;
+  });
+  return output;
+}
+
+function pickUsedPrefixes(
+  quads: ReadonlyArray<Quad>,
+  prefixes: Record<string, string>,
+): Record<string, string> {
+  const entries = Object.entries(prefixes);
+  if (entries.length === 0) return {};
+
+  const usedNames = new Set<string>();
+  for (const q of quads) {
+    for (const term of [q.subject, q.predicate, q.object, q.graph]) {
+      const name = bestPrefixFor(term, entries);
+      if (name) usedNames.add(name);
+    }
+  }
+
+  const out: Record<string, string> = {};
+  for (const [name, iri] of entries) {
+    if (usedNames.has(name)) out[name] = iri;
+  }
+  return out;
+}
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+function compareQuads(a: Quad, b: Quad): number {
+  return (
+    compareTerm(a.graph, b.graph) ||
+    compareTerm(a.subject, b.subject) ||
+    comparePredicate(a.predicate, b.predicate) ||
+    compareTerm(a.object, b.object)
+  );
+}
+
+function comparePredicate(a: Term, b: Term): number {
+  const aIsType = a.termType === 'NamedNode' && a.value === RDF_TYPE;
+  const bIsType = b.termType === 'NamedNode' && b.value === RDF_TYPE;
+  if (aIsType && !bIsType) return -1;
+  if (!aIsType && bIsType) return 1;
+  return compareTerm(a, b);
+}
+
+function compareTerm(a: Term, b: Term): number {
+  const aKey = termKey(a);
+  const bKey = termKey(b);
+  return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
+}
+
+function termKey(term: Term): string {
+  switch (term.termType) {
+    case 'DefaultGraph':
+      return '0:';
+    case 'NamedNode':
+      return `1:${term.value}`;
+    case 'BlankNode':
+      return `2:${term.value}`;
+    case 'Literal': {
+      const lit = term as Term & {
+        language?: string;
+        datatype?: { value: string };
+      };
+      return `3:${term.value}${lit.datatype?.value ?? ''}${lit.language ?? ''}`;
+    }
+    default:
+      return `9:${term.value}`;
+  }
+}
+
+function bestPrefixFor(
+  term: Term,
+  entries: ReadonlyArray<[string, string]>,
+): string | undefined {
+  if (term.termType !== 'NamedNode') return undefined;
+  const iri = term.value;
+  let bestName: string | undefined;
+  let bestLength = -1;
+  for (const [name, prefIri] of entries) {
+    if (iri.startsWith(prefIri) && prefIri.length > bestLength) {
+      bestName = name;
+      bestLength = prefIri.length;
+    }
+  }
+  return bestName;
+}

--- a/libs/core/src/lib/rdf-loader.spec.ts
+++ b/libs/core/src/lib/rdf-loader.spec.ts
@@ -318,6 +318,38 @@ describe('loadRdf', () => {
     expect(quad.graph.termType).toBe('DefaultGraph');
   });
 
+  it('captures per-file prefixes declared in turtle source', async () => {
+    const file = join(dir, 'a.ttl');
+    await writeFile(
+      file,
+      [
+        '@prefix ex: <http://example.org/> .',
+        '@prefix dct: <http://purl.org/dc/terms/> .',
+        'ex:a ex:p ex:b .',
+      ].join('\n'),
+    );
+    const result = await loadRdf({ sources: join(dir, '*.ttl') });
+    expect(result.prefixes[file]).toEqual({
+      ex: 'http://example.org/',
+      dct: 'http://purl.org/dc/terms/',
+    });
+  });
+
+  it('captures per-file prefixes from trig source', async () => {
+    const file = join(dir, 'a.trig');
+    await writeFile(
+      file,
+      [
+        '@prefix ex: <http://example.org/> .',
+        'ex:g { ex:a ex:p ex:b . }',
+      ].join('\n'),
+    );
+    const result = await loadRdf({ sources: join(dir, '*.trig') });
+    expect(result.prefixes[file]).toEqual({
+      ex: 'http://example.org/',
+    });
+  });
+
   it('graphStrategy=full: gives each file its own named graph', async () => {
     const a = join(dir, 'a.ttl');
     const b = join(dir, 'b.ttl');

--- a/libs/core/src/lib/rdf-loader.ts
+++ b/libs/core/src/lib/rdf-loader.ts
@@ -21,6 +21,8 @@ export interface LoadOptions {
 export interface LoadResult {
   store: Store;
   files: string[];
+  /** Prefixes declared in each parsed file, keyed by absolute file path. */
+  prefixes: Record<string, Record<string, string>>;
 }
 
 const EXTENSION_TO_CONTENT_TYPE: Record<string, string> = {
@@ -53,6 +55,7 @@ export async function loadRdf(options: LoadOptions): Promise<LoadResult> {
 
   const strategy: GraphStrategy = options.graphStrategy ?? 'default';
   const store = new Store();
+  const prefixes: Record<string, Record<string, string>> = {};
 
   for (const file of files) {
     const contentType = contentTypeFor(file);
@@ -60,14 +63,14 @@ export async function loadRdf(options: LoadOptions): Promise<LoadResult> {
       throw new Error(`Unsupported file extension: ${file}`);
     }
     try {
-      await parseFileInto(file, contentType, store, strategy);
+      prefixes[file] = await parseFileInto(file, contentType, store, strategy);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       throw new Error(`Failed to parse ${file}: ${message}`);
     }
   }
 
-  return { store, files };
+  return { store, files, prefixes };
 }
 
 function contentTypeFor(file: string): string | undefined {
@@ -92,8 +95,9 @@ function parseFileInto(
   contentType: string,
   store: Store,
   strategy: GraphStrategy,
-): Promise<void> {
+): Promise<Record<string, string>> {
   const fileGraph = DataFactory.namedNode(`file://${file}`);
+  const filePrefixes: Record<string, string> = {};
   return new Promise((resolve, reject) => {
     const stream = createReadStream(file);
     stream.on('error', reject);
@@ -106,7 +110,10 @@ function parseFileInto(
           : quad;
         store.addQuad(out);
       })
+      .on('prefix', (prefix: string, iri: NamedNode) => {
+        if (prefix && iri?.value) filePrefixes[prefix] = iri.value;
+      })
       .on('error', reject)
-      .on('end', resolve);
+      .on('end', () => resolve(filePrefixes));
   });
 }


### PR DESCRIPTION
Closes #32.

## Summary

- New `formatRdf(quads, 'turtle'|'trig', { prefixes })` in `libs/core` — drops unused prefixes, sorts deterministically (rdf:type as `a` first), groups TriG output by graph, delegates serialization to n3's `Writer`.
- `loadRdf` now also returns a per-file prefixes map captured from `rdf-parse`'s `prefix` event.
- `sparqly format [glob]` reads a glob of `.ttl`/`.trig` files (or Turtle/TriG from stdin when no glob is given), preserves file-declared prefixes, and prints the result to stdout.

## Acceptance criteria

- [x] Formatter module exposes `(quads, serialization, resolvedConfig) => string`
- [x] `sparqly format <glob>` formats `.ttl` and `.trig` files via the same glob shape as `query`
- [x] Stdin accepted when no positional glob is supplied
- [x] File-declared prefixes preserved; unmatched IRIs stay full; unused prefixes dropped
- [x] Output is deterministic and idempotent (`format(format(x)) == format(x)`)
- [x] Round-trip safe (`canonicalizeRdf(parse(format(x))) == canonicalizeRdf(parse(x))`)
- [x] Golden-snapshot, idempotency, and round-trip harnesses in place over a small starter corpus
- [x] E2E for `format` happy path (glob input, stdin input)

## Out of scope (deferred to later slices per parent PRD)

List compaction, blank-node inlining, inverse-placed predicates, `@base`, `--write`, `--check`, `--prefix` CLI flag, config-driven prefix overrides, and the `format:` config block.

## Test plan

- [x] `nx run-many -t build lint test` (268 unit tests passing)
- [x] `nx e2e cli-e2e` (104 e2e tests passing, including 3 new ones for `format`)
- [x] Manual smoke: `sparqly format apps/cli-e2e/fixtures/format/simple.ttl`