### PR TITLE
feat(web): meaningful document titles per page (ADR-0053)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,10 @@ _Avoid_: "SPO query", "graph-shaped SELECT", "triple SELECT"
 A SPARQL query passed directly to `query`, `hash`, or `diff` and run against the **target source** — the only derivation sparqly performs, since there is no derived **Source**. On `diff`, an arbitrary `SELECT` tuple selects **tabular diff** over **graph diff**; `hash` and graph-`diff` require a query that produces triples (`CONSTRUCT` or a **triple-shaped SELECT**). Never persisted, never `@id`-addressable.
 _Avoid_: "anonymous view", "ad-hoc view", "view"
 
+**Playground**:
+The webapp's home surface for composing and running an **inline query** against a single selected source; it is also a **Saved-query run surface**. "Playground" is this page's UI and nav label — the canonical user-facing name for what is described elsewhere as the "query page".
+_Avoid_: extending "Playground" to the other **Saved-query run surfaces** (e.g. the `diff` page's loaders); "query playground" as a synonym for the run-surface concept itself.
+
 ### Registries & targets
 
 **Source registry**:
@@ -164,7 +168,7 @@ _Avoid_: "queries library page", "saved-query manager"
 
 **Saved-query run surface**:
 A webapp surface that consumes **Saved query** entries without authoring them — today, the `query` page and each side of the `diff` page. Exposes Load and the runtime parameter form only, never Save, Save-as, Delete, or parameter authoring.
-_Avoid_: "read-only editor", "query playground", conflating with **Saved-query authoring surface**
+_Avoid_: "read-only editor", "query playground" (the **Playground** is one specific host of this surface, not a synonym for it), conflating with **Saved-query authoring surface**
 
 **Templated saved query**:
 A **Saved query** with a non-empty **Parameter declaration** list; at run time the supplied values are composed into a `VALUES` clause prepended to the body. The template body itself is always valid SPARQL — there is no text-level placeholder syntax.

--- a/apps/cli/project.json
+++ b/apps/cli/project.json
@@ -8,7 +8,11 @@
     "build": {
       "executor": "nx:run-commands",
       "dependsOn": ["^build", "web:build"],
-      "inputs": ["production", "^production"],
+      "inputs": [
+        "production",
+        "^production",
+        { "dependentTasksOutputFiles": "**/*", "transitive": false }
+      ],
       "outputs": ["{workspaceRoot}/dist/apps/cli"],
       "options": {
         "command": "webpack-cli build",

--- a/apps/web-e2e/src/describe.spec.ts
+++ b/apps/web-e2e/src/describe.spec.ts
@@ -36,6 +36,9 @@ test.describe('describe page · single-source picker', () => {
     // The URL is rewritten with the fully-expanded seed on submit so the page
     // is bookmarkable.
     await expect(page).toHaveURL(/[?&]iri=http(?::|%3A)%2F%2Fexample\.org%2Fbob/);
+
+    // ADR-0053: the document title carries the described seed as a curie.
+    await expect(page).toHaveTitle('ex:bob — Describe — sparqly');
   });
 
   test('picking another source rescopes the page and rewrites the URL', async ({

--- a/apps/web-e2e/src/queries.spec.ts
+++ b/apps/web-e2e/src/queries.spec.ts
@@ -64,6 +64,9 @@ test.describe('queries page · create → list → load → run', () => {
       page.getByRole('heading', { level: 2, name: SLUG }),
     ).toBeVisible();
 
+    // ADR-0053: a loaded saved query surfaces its slug in the document title.
+    await expect(page).toHaveTitle(`${SLUG} — Queries — sparqly`);
+
     // Run — the sources picker auto-selects the default source on mount,
     // so the Run button is enabled out of the box.
     const runBtn = page.getByRole('button', { name: 'Run', exact: true });

--- a/apps/web-e2e/src/smoke.spec.ts
+++ b/apps/web-e2e/src/smoke.spec.ts
@@ -7,6 +7,7 @@ test.describe('per-page smoke', () => {
       page.getByRole('heading', { level: 1, name: 'sparqly playground' }),
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Run' })).toBeVisible();
+    await expect(page).toHaveTitle(/ — Playground — sparqly$/);
   });
 
   test('/diff renders the diff page', async ({ page }) => {
@@ -14,6 +15,7 @@ test.describe('per-page smoke', () => {
     await expect(
       page.getByRole('heading', { level: 1, name: 'diff' }),
     ).toBeVisible();
+    await expect(page).toHaveTitle(/Diff — sparqly$/);
   });
 
   test('/describe renders the describe page', async ({ page }) => {
@@ -22,6 +24,7 @@ test.describe('per-page smoke', () => {
       page.getByRole('heading', { level: 1, name: 'describe' }),
     ).toBeVisible();
     await expect(page.getByRole('button', { name: 'Describe' })).toBeVisible();
+    await expect(page).toHaveTitle('Describe — sparqly');
   });
 
   test('/queries renders the saved-queries page', async ({ page }) => {
@@ -32,6 +35,7 @@ test.describe('per-page smoke', () => {
     await expect(
       page.getByText('Select an entry to view its body.'),
     ).toBeVisible();
+    await expect(page).toHaveTitle('Queries — sparqly');
   });
 
   test('/sources renders the sources page', async ({ page }) => {
@@ -39,5 +43,6 @@ test.describe('per-page smoke', () => {
     await expect(
       page.getByRole('heading', { level: 1, name: 'sources' }),
     ).toBeVisible();
+    await expect(page).toHaveTitle('Sources — sparqly');
   });
 });

--- a/apps/web/src/app/core/index.ts
+++ b/apps/web/src/app/core/index.ts
@@ -40,3 +40,5 @@ export {
   detectQueryType,
   type QueryType,
 } from './utils/query-detection';
+export { pageTitle } from './utils/page-title';
+export { sourceTitleToken } from './utils/source-title-token';

--- a/apps/web/src/app/core/utils/page-title.spec.ts
+++ b/apps/web/src/app/core/utils/page-title.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { pageTitle } from './page-title';
+
+describe('pageTitle', () => {
+  it('joins a value, the page name, and the brand with em-dashes', () => {
+    expect(pageTitle('foaf:Person', 'Describe')).toBe(
+      'foaf:Person — Describe — sparqly',
+    );
+  });
+
+  it('drops the value segment when it is empty or null', () => {
+    expect(pageTitle('', 'Sources')).toBe('Sources — sparqly');
+    expect(pageTitle(null, 'Sources')).toBe('Sources — sparqly');
+    expect(pageTitle('   ', 'Sources')).toBe('Sources — sparqly');
+  });
+});

--- a/apps/web/src/app/core/utils/page-title.ts
+++ b/apps/web/src/app/core/utils/page-title.ts
@@ -1,0 +1,11 @@
+const BRAND = 'sparqly';
+
+/**
+ * Assemble a document title as `value — Page — sparqly`, collapsing to
+ * `Page — sparqly` when there is no meaningful value. The single place the
+ * em-dash join and brand suffix live (ADR-0053).
+ */
+export function pageTitle(value: string | null, page: string): string {
+  const trimmed = value?.trim() ?? '';
+  return [trimmed, page, BRAND].filter((part) => part.length > 0).join(' — ');
+}

--- a/apps/web/src/app/core/utils/source-title-token.spec.ts
+++ b/apps/web/src/app/core/utils/source-title-token.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { sourceTitleToken } from './source-title-token';
+
+describe('sourceTitleToken', () => {
+  it('renders a pinned address as id@ref', () => {
+    expect(sourceTitleToken('@dbpedia:2024')).toBe('dbpedia@2024');
+  });
+
+  it('passes a plain id through unchanged', () => {
+    expect(sourceTitleToken('dbpedia')).toBe('dbpedia');
+  });
+
+  it('returns empty for no source', () => {
+    expect(sourceTitleToken('')).toBe('');
+  });
+
+  it('drops the @ when an address carries no ref', () => {
+    expect(sourceTitleToken('@dbpedia')).toBe('dbpedia');
+    expect(sourceTitleToken('@dbpedia:')).toBe('dbpedia:');
+  });
+});

--- a/apps/web/src/app/core/utils/source-title-token.ts
+++ b/apps/web/src/app/core/utils/source-title-token.ts
@@ -1,0 +1,15 @@
+/**
+ * Render a source picker value as a compact title token: a pinned address
+ * `@id:ref` becomes `id@ref`, a plain id passes through. Self-contained
+ * parsing — mirrors the picker's private `splitPinnedAddress` (ADR-0053).
+ */
+export function sourceTitleToken(value: string): string {
+  if (!value.startsWith('@')) return value;
+  const body = value.slice(1);
+  const lastColon = body.lastIndexOf(':');
+  if (lastColon === -1) return body;
+  const id = body.slice(0, lastColon);
+  const ref = body.slice(lastColon + 1);
+  if (id.length === 0 || ref.length === 0) return body;
+  return `${id}@${ref}`;
+}

--- a/apps/web/src/app/pages/describe/describe.page.ts
+++ b/apps/web/src/app/pages/describe/describe.page.ts
@@ -8,11 +8,12 @@ import {
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { ButtonComponent } from '@app/modules/button';
 import { ErrorBannerComponent } from '@app/modules/error-banner';
 import { EyebrowComponent } from '@app/modules/eyebrow';
 import { SourcesPickerComponent } from '@app/modules/sources-picker';
-import { ConfigService, type DisplayContext } from '@app/core';
+import { ConfigService, pageTitle, type DisplayContext } from '@app/core';
 import { FormattedResultComponent } from '@app/pages/query/components/result/formatted-result.component';
 import {
   resultToFormatted,
@@ -23,6 +24,7 @@ import type { FormatSerialization, PathStep } from 'common';
 import type { Quad } from 'n3';
 import { DescribeSectionsComponent } from './components/describe-sections.component';
 import { describeIriExpand } from './utils/describe-iri-expand';
+import { describeTitleValue } from './utils/describe-title-value';
 import { describeErrorMessage } from './utils/describe-error-message';
 import type { DescribeBnodePathResult } from './utils/describe-bnode-path';
 import {
@@ -147,6 +149,7 @@ export class DescribePage implements OnInit {
   private readonly configService = inject(ConfigService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly title = inject(Title);
 
   readonly seed = signal<string>('');
   readonly submittedSeed = signal<string>('');
@@ -217,6 +220,14 @@ export class DescribePage implements OnInit {
         queryParamsHandling: 'merge',
         replaceUrl: true,
       });
+    });
+
+    effect(() => {
+      const value = describeTitleValue(
+        this.submittedSeed(),
+        this.displayContext(),
+      );
+      this.title.setTitle(pageTitle(value, 'Describe'));
     });
   }
 

--- a/apps/web/src/app/pages/describe/utils/describe-title-value.spec.ts
+++ b/apps/web/src/app/pages/describe/utils/describe-title-value.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { describeTitleValue } from './describe-title-value';
+
+const CTX = {
+  prefixes: { foaf: 'http://xmlns.com/foaf/0.1/' },
+  base: 'http://example.org/',
+};
+
+describe('describeTitleValue', () => {
+  it('renders the submitted seed as a curie against the display context', () => {
+    expect(
+      describeTitleValue('http://xmlns.com/foaf/0.1/Person', CTX),
+    ).toBe('foaf:Person');
+  });
+
+  it('is empty when nothing has been submitted yet', () => {
+    expect(describeTitleValue('', CTX)).toBe('');
+    expect(describeTitleValue('   ', CTX)).toBe('');
+  });
+});

--- a/apps/web/src/app/pages/describe/utils/describe-title-value.ts
+++ b/apps/web/src/app/pages/describe/utils/describe-title-value.ts
@@ -1,0 +1,16 @@
+import type { DisplayContext } from '@app/core';
+import { curieOrIri } from '../../diff/utils/term-display';
+
+/**
+ * The describe page title value: the submitted (fully-expanded) seed IRI
+ * rendered as a curie via the shared `curieOrIri`, or empty before anything
+ * has been described (ADR-0053).
+ */
+export function describeTitleValue(
+  submittedSeed: string,
+  ctx: DisplayContext,
+): string {
+  const iri = submittedSeed.trim();
+  if (iri.length === 0) return '';
+  return curieOrIri(iri, Object.entries(ctx.prefixes), ctx.base);
+}

--- a/apps/web/src/app/pages/diff/diff.page.ts
+++ b/apps/web/src/app/pages/diff/diff.page.ts
@@ -8,6 +8,7 @@ import {
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { ButtonComponent } from '@app/modules/button';
 import { CodeChipComponent } from '@app/modules/code-chip';
 import { ErrorBannerComponent } from '@app/modules/error-banner';
@@ -17,11 +18,14 @@ import { SourcesPickerComponent } from '@app/modules/sources-picker';
 import {
   ConfigService,
   SavedQueriesService,
+  pageTitle,
+  sourceTitleToken,
   type DisplayContext,
   type SavedQuerySummary,
   type SourceListingEntry,
 } from '@app/core';
 import { DiffService } from './services/diff.service';
+import { diffTitleValue } from './utils/diff-title-value';
 import type { DiffError, DiffErrorResponse } from './models/diff-error';
 import type { DiffRequest, DiffResponse } from './models/diff-response';
 import { formatDiffError } from './utils/format-error';
@@ -211,6 +215,7 @@ export class DiffPage implements OnInit {
   private readonly savedQueriesService = inject(SavedQueriesService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly title = inject(Title);
 
   readonly sources = signal<SourceListingEntry[] | null>(null);
   readonly leftId = signal<string>('');
@@ -253,6 +258,14 @@ export class DiffPage implements OnInit {
     if (right) this.rightId.set(right);
     if (leftQuery !== null) this.leftSide.query.set(leftQuery);
     if (rightQuery !== null) this.rightSide.query.set(rightQuery);
+
+    effect(() => {
+      const value = diffTitleValue(
+        sourceTitleToken(this.leftId()),
+        sourceTitleToken(this.rightId()),
+      );
+      this.title.setTitle(pageTitle(value, 'Diff'));
+    });
 
     effect(() => {
       const queryParams: Record<string, string | null> = {

--- a/apps/web/src/app/pages/diff/utils/diff-title-value.spec.ts
+++ b/apps/web/src/app/pages/diff/utils/diff-title-value.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { diffTitleValue } from './diff-title-value';
+
+describe('diffTitleValue', () => {
+  it('joins two distinct source tokens with an arrow', () => {
+    expect(diffTitleValue('repo@v1', 'repo@v2')).toBe('repo@v1 → repo@v2');
+  });
+
+  it('collapses to a single token when both sides are identical', () => {
+    expect(diffTitleValue('repo@v1', 'repo@v1')).toBe('repo@v1');
+  });
+
+  it('reduces to the present side when the other is empty', () => {
+    expect(diffTitleValue('repo@v1', '')).toBe('repo@v1');
+    expect(diffTitleValue('', 'repo@v2')).toBe('repo@v2');
+  });
+
+  it('returns empty when both sides are empty', () => {
+    expect(diffTitleValue('', '')).toBe('');
+  });
+});

--- a/apps/web/src/app/pages/diff/utils/diff-title-value.ts
+++ b/apps/web/src/app/pages/diff/utils/diff-title-value.ts
@@ -1,0 +1,10 @@
+/**
+ * The title value for the diff page: the two side source tokens joined by an
+ * arrow, collapsed to a single token when both sides resolve to the same one
+ * (mirroring the describe-this affordance precedent), and reduced to whatever
+ * is present when a side is empty (ADR-0053).
+ */
+export function diffTitleValue(left: string, right: string): string {
+  const tokens = [left, right].filter((token) => token.length > 0);
+  return [...new Set(tokens)].join(' → ');
+}

--- a/apps/web/src/app/pages/queries/queries.page.ts
+++ b/apps/web/src/app/pages/queries/queries.page.ts
@@ -3,16 +3,19 @@ import {
   Component,
   computed,
   DestroyRef,
+  effect,
   inject,
   OnInit,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import { combineLatest } from 'rxjs';
 import {
   ConfigService,
   SavedQueriesService,
+  pageTitle,
   type LoadedSavedQuery,
   type SavedQuerySummary,
 } from '@app/core';
@@ -27,6 +30,7 @@ import {
 import { QueriesRailComponent } from './components/queries-rail.component';
 import type { CreateNavState } from './models/create-nav-state';
 import type { DetailState } from './models/detail-state';
+import { queriesTitleValue } from './utils/queries-title-value';
 import { toWriteBody } from './utils/to-write-body';
 
 @Component({
@@ -99,6 +103,7 @@ export class QueriesPage implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly title = inject(Title);
 
   readonly entries = signal<readonly SavedQuerySummary[]>([]);
   readonly selectedSlug = signal<string | null>(null);
@@ -132,6 +137,12 @@ export class QueriesPage implements OnInit {
       parameters: d.loadedParameters,
     };
   });
+
+  constructor() {
+    effect(() => {
+      this.title.setTitle(pageTitle(queriesTitleValue(this.detail()), 'Queries'));
+    });
+  }
 
   ngOnInit(): void {
     const source = this.route.snapshot.queryParamMap.get('source');

--- a/apps/web/src/app/pages/queries/utils/queries-title-value.spec.ts
+++ b/apps/web/src/app/pages/queries/utils/queries-title-value.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { queriesTitleValue } from './queries-title-value';
+
+describe('queriesTitleValue', () => {
+  it('uses the slug of a loaded saved query', () => {
+    expect(
+      queriesTitleValue({
+        kind: 'loaded',
+        slug: 'orphaned-nodes',
+        loadedBody: 'SELECT * WHERE { ?s ?p ?o }',
+        loadedEtag: 'etag',
+        loadedParameters: [],
+      }),
+    ).toBe('orphaned-nodes');
+  });
+
+  it('uses the slug while a saved query is loading', () => {
+    expect(queriesTitleValue({ kind: 'loading', slug: 'big-query' })).toBe(
+      'big-query',
+    );
+  });
+
+  it("labels the create route 'New query'", () => {
+    expect(
+      queriesTitleValue({
+        kind: 'create',
+        origin: null,
+        prefillBody: '',
+        prefillParameters: [],
+      }),
+    ).toBe('New query');
+  });
+
+  it("labels an unknown slug 'Not found'", () => {
+    expect(queriesTitleValue({ kind: 'not-found', slug: 'ghost' })).toBe(
+      'Not found',
+    );
+  });
+
+  it('is empty for the bare list', () => {
+    expect(queriesTitleValue({ kind: 'empty' })).toBe('');
+  });
+});

--- a/apps/web/src/app/pages/queries/utils/queries-title-value.ts
+++ b/apps/web/src/app/pages/queries/utils/queries-title-value.ts
@@ -1,0 +1,20 @@
+import type { DetailState } from '../models/detail-state';
+
+/**
+ * The queries page title value, derived from its detail state (ADR-0053):
+ * the slug while a saved query is loading or loaded, a label for the create
+ * and not-found states, and empty for the bare list.
+ */
+export function queriesTitleValue(detail: DetailState): string {
+  switch (detail.kind) {
+    case 'loaded':
+    case 'loading':
+      return detail.slug;
+    case 'create':
+      return 'New query';
+    case 'not-found':
+      return 'Not found';
+    case 'empty':
+      return '';
+  }
+}

--- a/apps/web/src/app/pages/query/query.page.ts
+++ b/apps/web/src/app/pages/query/query.page.ts
@@ -13,15 +13,19 @@ import {
   signal,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 import {
   ConfigService,
   SavedQueriesService,
   decodeSparqlResult,
   detectQueryType,
+  pageTitle,
+  sourceTitleToken,
   type DisplayContext,
   type SavedQuerySummary,
   type SourceListingEntry,
 } from '@app/core';
+import { queryTitleSnippet } from './utils/query-title-snippet';
 import {
   substitute,
   type ParameterBindings,
@@ -119,6 +123,7 @@ export class QueryPage implements OnInit {
   private readonly http = inject(HttpClient);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly title = inject(Title);
 
   readonly sources = signal<SourceListingEntry[] | null>(null);
   readonly sourceId = signal<string>('');
@@ -161,6 +166,13 @@ export class QueryPage implements OnInit {
         this.knownBindKeys.set(new Set(Object.keys(parsed)));
       }
     }
+
+    effect(() => {
+      const source = sourceTitleToken(this.sourceId());
+      const snippet = queryTitleSnippet(this.query());
+      const value = [source, snippet].filter((part) => part.length > 0).join(' · ');
+      this.title.setTitle(pageTitle(value, 'Playground'));
+    });
 
     effect(() => {
       const pinned = this.pinnedSlug();

--- a/apps/web/src/app/pages/query/utils/query-title-snippet.spec.ts
+++ b/apps/web/src/app/pages/query/utils/query-title-snippet.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { queryTitleSnippet } from './query-title-snippet';
+
+describe('queryTitleSnippet', () => {
+  it('drops leading PREFIX declarations and starts at the query body', () => {
+    const body = [
+      'PREFIX foaf: <http://xmlns.com/foaf/0.1/>',
+      'PREFIX ex: <http://example.org/>',
+      'SELECT ?s WHERE { ?s a foaf:Person }',
+    ].join('\n');
+    expect(queryTitleSnippet(body)).toBe('SELECT ?s WHERE { ?s a foaf:Person }');
+  });
+
+  it('truncates a long body to ~40 chars with an ellipsis', () => {
+    const body =
+      'SELECT ?subject ?predicate ?object WHERE { ?subject ?predicate ?object }';
+    expect(queryTitleSnippet(body)).toBe(
+      'SELECT ?subject ?predicate ?object WHERE…',
+    );
+  });
+
+  it('skips leading comments, blank lines, and BASE before the body', () => {
+    const body = [
+      '# entities missing a label',
+      '',
+      'BASE <http://example.org/>',
+      '',
+      'ASK { ?s ?p ?o }',
+    ].join('\n');
+    expect(queryTitleSnippet(body)).toBe('ASK { ?s ?p ?o }');
+  });
+
+  it('returns empty for an empty body', () => {
+    expect(queryTitleSnippet('')).toBe('');
+    expect(queryTitleSnippet('   \n  ')).toBe('');
+  });
+
+  it('returns empty when the buffer is all preamble', () => {
+    const body = 'PREFIX ex: <http://example.org/>\n# nothing else yet';
+    expect(queryTitleSnippet(body)).toBe('');
+  });
+});

--- a/apps/web/src/app/pages/query/utils/query-title-snippet.ts
+++ b/apps/web/src/app/pages/query/utils/query-title-snippet.ts
@@ -1,0 +1,28 @@
+/**
+ * The leading, non-body part of a query: PREFIX/BASE declarations, comment
+ * lines, and blank lines, in any order at the top of the buffer.
+ */
+function isPreamble(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.length === 0 ||
+    trimmed.startsWith('#') ||
+    /^(PREFIX|BASE)\b/i.test(trimmed)
+  );
+}
+
+/**
+ * Derive a compact, title-friendly snippet of a SPARQL query body: skip the
+ * leading PREFIX/BASE/comment/blank preamble, collapse whitespace, and take
+ * the first ~40 characters of the real query (ADR-0053).
+ */
+const MAX_LEN = 40;
+
+export function queryTitleSnippet(body: string): string {
+  const lines = body.split('\n');
+  let start = 0;
+  while (start < lines.length && isPreamble(lines[start])) start++;
+  const snippet = lines.slice(start).join(' ').replace(/\s+/g, ' ').trim();
+  if (snippet.length <= MAX_LEN) return snippet;
+  return `${snippet.slice(0, MAX_LEN).trimEnd()}…`;
+}

--- a/apps/web/src/app/pages/sources/sources.page.ts
+++ b/apps/web/src/app/pages/sources/sources.page.ts
@@ -5,6 +5,8 @@ import {
   inject,
   signal,
 } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { pageTitle } from '@app/core';
 import { SourceCardComponent } from './components/source-card.component';
 import {
   SourceFilterBarComponent,
@@ -77,6 +79,11 @@ import { SourcesRegistryService } from './services/sources-registry.service';
 })
 export class SourcesPage {
   private readonly registry = inject(SourcesRegistryService);
+  private readonly title = inject(Title);
+
+  constructor() {
+    this.title.setTitle(pageTitle('', 'Sources'));
+  }
 
   readonly rows = this.registry.rows;
   readonly allowAdminActions = this.registry.allowAdminActions;

--- a/docs/adr/0053-webapp-document-title-strategy.md
+++ b/docs/adr/0053-webapp-document-title-strategy.md
@@ -1,0 +1,22 @@
+# Webapp document title strategy
+
+Every webapp page sets a `value — Page — sparqly` document title (collapsing to `Page — sparqly` when there is no value), where `Page` is the nav-label name and `value` is the page's most identifying per-instance state. We wire this **per component** — each page injects Angular's `Title` service and recomputes the title inside an `effect()` via a shared `pageTitle(value, page)` helper — rather than using Angular's idiomatic `TitleStrategy` + route `title`, because our titles are signal-reactive (the Playground title changes as you type, Describe's seed comes from a query param, Diff's sources from pickers), and `TitleStrategy` only fires on navigation. `index.html` keeps a static `sparqly` as the pre-bootstrap fallback.
+
+## Considered options
+
+- **`TitleStrategy` + route `title`** (the framework default): centralizes the ` — sparqly` suffix and handles static titles cleanly, but it re-runs on navigation and cannot react to in-page signal changes — it would fight the components' reactive titles and leave a split-brain (two sources of truth).
+- **Route resolvers**: clean for URL-derived titles (slug, describe seed) but cannot react after activation, so the Playground snippet would never update as you type. Disqualified.
+- **Per-component reactive (chosen)**: one uniform mechanism everywhere, fully reactive, at the cost of decentralization and deviating from the framework convention.
+
+## Per-page values
+
+- **Playground** (`/`): `{source id, + @ref when pinned} · {first ~40 chars of the query body}` — the body has its leading `PREFIX`/`BASE` declarations, comments, and blank lines stripped and whitespace collapsed before truncation.
+- **Diff** (`/diff`): `{left token} → {right token}` (sources only), collapsed to a single token when both sides resolve to the same id+ref — mirroring the describe-this affordance precedent in `CONTEXT.md`.
+- **Describe** (`/describe`): the seed rendered through the existing `curieOrIri` util (curie, else `<IRI>`); `Describe` alone before a seed is entered.
+- **Queries** (`/queries…`): the `slug` when one is loaded or loading (known from the URL, so no loading flicker); `New query` for `/queries/new`; `Not found` for an unknown slug; `Queries` for the list.
+- **Sources** (`/sources`): static `Sources`.
+
+## Consequences
+
+- Adding a new page means adding a `Title` injection + `effect()` + `pageTitle(...)` call; there is no central registry to update, and no route-data title to keep in sync.
+- The Playground title tracks the live editor buffer, so it updates on every keystroke (debounced only by Angular's effect scheduling); it deliberately does not surface the loaded saved-query `slug`, since the source + body snippet identify the tab more faithfully once a draft is edited.


### PR DESCRIPTION
## What

Every webapp page now sets a meaningful `<title>` instead of the static `sparqly`. The pattern is uniform: `value — Page — sparqly`, collapsing to `Page — sparqly` when there is no value.

| Route | Example title |
|---|---|
| `/` (Playground) | `alpha · SELECT ?s ?p ?o WHERE { ?s ?p ?o . } LIM… — Playground — sparqly` |
| `/diff` | `repo@v1 → repo@v2 — Diff — sparqly` (collapses to one when both sides match) |
| `/describe?iri=…` | `ex:bob — Describe — sparqly` |
| `/queries/:slug` | `my-slug — Queries — sparqly` (also `New query`, `Not found`, `Queries`) |
| `/sources` | `Sources — sparqly` |

## How

Titles are heavily reactive (Playground tracks the editor buffer, describe's seed comes from the URL, diff's sources from the pickers), so each page injects Angular's `Title` and recomputes inside an `effect()` via a shared `pageTitle(value, page)` helper — **not** Angular's navigation-time `TitleStrategy`. Rationale recorded in **ADR-0053**.

Per-page value derivation lives in small pure helpers, each unit-tested:
- `pageTitle`, `sourceTitleToken` (`@id:ref` → `id@ref`)
- `queryTitleSnippet` (strip PREFIX/BASE/comment/blank preamble, collapse whitespace, ~40 chars + ellipsis)
- `diffTitleValue` (arrow-join, collapse identical/empty)
- `describeTitleValue` (curie via the existing `curieOrIri`)
- `queriesTitleValue` (detail-state → label)

## Docs

- `CONTEXT.md`: blessed **Playground** as the query page's UI label (reconciling the nav pill vs the glossary's "query page"), and scoped the saved-query run-surface `_Avoid: "query playground"`.
- `docs/adr/0053-webapp-document-title-strategy.md`.

## Drive-by fix

The CLI serves the web app from a copy embedded at `nx build cli` time (`dist/apps/cli/web`), but the cli build's cache key did not include web's output — so any web-only change served a **stale** bundle until the cache was busted (this also affects `pnpm run sparqly`). Added a `dependentTasksOutputFiles` input to `apps/cli/project.json`. This was the sole cause of the e2e initially failing; the title code was correct throughout.

## Testing

- **Unit:** 22 new tests across 6 helpers; web suite **618/618**, lint clean.
- **E2e:** `toHaveTitle` assertions added to `smoke` (all 5 pages), `describe` (seed → curie), `queries` (loaded slug); web e2e **22/22**.
- **Manual:** verified all five live titles in a real browser against a fresh serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)