### PR TITLE
fix(diff): enumerate pinned globs from the git tree, not the working tree

### DIFF
--- a/libs/core/src/lib/inline-query/execute-inline-query.ts
+++ b/libs/core/src/lib/inline-query/execute-inline-query.ts
@@ -1,20 +1,23 @@
 import { QueryEngine as ComunicaQueryEngine } from '@comunica/query-sparql';
 import { DataFactory, Store, type Quad } from 'n3';
-import { ResultAsync, okAsync } from 'neverthrow';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
 import type { SparqlyLogger } from 'common';
 import { emitQueryEvent, loadRdfResult } from '../engine';
 import { detectQueryType } from '../canonical/immutability';
 import {
   applyTransformPipeline,
+  resolveSourceResult,
   storageTier,
   unionDefaultGraphEnabled,
   type ParsedEmptySource,
   type ParsedFileSource,
   type ParsedGlobSource,
   type ParsedSource,
+  type SourceError,
 } from '../sources';
 import type {
   EndpointFetchError,
+  GitPinError,
   GlobLoadError,
   QueryExecutionError,
   InlineQueryValidationError,
@@ -34,7 +37,8 @@ export type ExecuteInlineQueryError =
   | EndpointFetchError
   | QueryExecutionError
   | GlobLoadError
-  | TransformParseError;
+  | TransformParseError
+  | GitPinError;
 
 export interface ExecuteInlineQueryOptions {
   engine?: ComunicaQueryEngine;
@@ -69,6 +73,24 @@ export function executeInlineQueryResult(
   if (upstream.kind === 'glob' && storageTier(upstream) === 'disk') {
     return runOverDiskBackedGlob(upstream, query, meta, options);
   }
+  if (upstream.kind === 'glob' && upstream.gitRef !== undefined) {
+    // A pinned glob must enumerate (and read) from the git tree at its resolved
+    // SHA — delegating to the shared resolver so a file present only at the ref
+    // is materialized rather than silently dropped (the working-tree glob would
+    // miss it). `loadUpstreamStore` ignores `gitRef`, so route around it.
+    return loadPinnedGlobStore(upstream, options).andThen<
+      Store,
+      ExecuteInlineQueryError
+    >((store) =>
+      runInMemoryQueryResult(
+        store,
+        query,
+        meta,
+        options.engine,
+        unionDefaultGraphEnabled(upstream),
+      ),
+    );
+  }
   return loadUpstreamStore(upstream, options).andThen<Store, ExecuteInlineQueryError>(
     (store) =>
       runInMemoryQueryResult(
@@ -101,6 +123,55 @@ function loadUpstreamStore(
       perFileRecords: sub.perFileRecords,
     }),
   );
+}
+
+function loadPinnedGlobStore(
+  upstream: ParsedGlobSource,
+  options: ExecuteInlineQueryOptions,
+): ResultAsync<Store, ExecuteInlineQueryError> {
+  return resolveSourceResult(upstream, {
+    logger: options.logger,
+    configDir: options.configDir,
+  })
+    .mapErr(narrowPinnedSourceError)
+    .andThen<Store, ExecuteInlineQueryError>((sources) => {
+      if (sources.mode === 'materialized') return okAsync(sources.store);
+      if (sources.mode === 'disk-backed') {
+        // Unreachable: `resolveSourceResult` rejects `gitRef` on a disk-backed
+        // glob before it can resolve. Release the lock and fail defensively.
+        void sources.close();
+        return errAsync<Store, ExecuteInlineQueryError>({
+          kind: 'glob-load',
+          glob: [upstream.glob],
+          message:
+            'inline query: disk-backed glob upstream (`storage: disk`) cannot be materialized at a pinned ref',
+        });
+      }
+      return errAsync<Store, ExecuteInlineQueryError>({
+        kind: 'glob-load',
+        glob: [upstream.glob],
+        message:
+          'inline query: pinned glob upstream unexpectedly resolved to a pass-through endpoint',
+      });
+    });
+}
+
+// `resolveSourceResult` can in principle surface every `SourceError`, but a
+// glob upstream never produces `reference-target` / `raw-pass-through-target`;
+// collapse those to inline-query-validation so the narrower
+// `ExecuteInlineQueryError` union stays exhaustive (mirrors the tabular path).
+function narrowPinnedSourceError(err: SourceError): ExecuteInlineQueryError {
+  if (err.kind === 'reference-target') {
+    return {
+      kind: 'inline-query-validation',
+      message:
+        "inline query: `kind: 'reference'` entries cannot be resolved as a target",
+    };
+  }
+  if (err.kind === 'raw-pass-through-target') {
+    return { kind: 'inline-query-validation', message: err.message };
+  }
+  return err;
 }
 
 function runOverDiskBackedGlob(

--- a/libs/core/src/lib/sources/resolve-source-result.ts
+++ b/libs/core/src/lib/sources/resolve-source-result.ts
@@ -135,23 +135,18 @@ function pinAndLoadGlob(
     .mapErr<SourceError>((e) => e)
     .andThen<MaterializedLoadResult, SourceError>((pinned) => {
       const transformPin = { ref: pinned.ref, sha: pinned.resolvedSha };
-      if (source.splitByFile === true) {
-        // Enumerate from the git tree at the resolved SHA so the load sees the
-        // ref-time file set, not the working tree's.
-        return loadPinnedSplitGlob(source, pinned, port, repoDiscovery)
-          .map((sub) => applyGlobTransforms(sub, transforms, transformPin));
-      }
-      return loadRdfResult({
-        sources: source.glob,
-        logger: options.logger,
-        contentReader: pinned.contentReader,
-      })
+      // Enumerate from the git tree at the resolved SHA so the load sees the
+      // ref-time file set, not the working tree's — otherwise a file present
+      // only at the ref (or absent from it) is silently mis-counted. Split and
+      // non-split globs load identically here; the split distinction only
+      // governs registry expansion into per-file children, not this load.
+      return loadPinnedGlobFromTree(source, pinned, port, repoDiscovery)
         .map((sub) => applyGlobTransforms(sub, transforms, transformPin))
         .orElse((err) => mapPinnedLoadError(err));
     });
 }
 
-function loadPinnedSplitGlob(
+function loadPinnedGlobFromTree(
   source: ParsedGlobSource,
   pinned: PinnedGlob,
   port: GitPort,

--- a/libs/server/src/lib/diff/diff.service.spec.ts
+++ b/libs/server/src/lib/diff/diff.service.spec.ts
@@ -456,6 +456,121 @@ describe('DiffService — pinned `@id:ref` address (ADR-0029)', () => {
   });
 });
 
+describe('DiffService — pinned split-glob diff with a ref-only file', () => {
+  let repo: string;
+
+  // Working tree holds only `a.ttl`; the `has-extra` branch additionally holds
+  // `extra.ttl`. A tabular SELECT diff of `@docs` (working tree) vs
+  // `@docs:has-extra` must surface the ref-only scheme — enumerating the glob
+  // against the git tree at the pinned SHA, not the working tree.
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), 'sparqly-diff-split-pin-'));
+    const aTtl = join(repo, 'a.ttl');
+    const extraTtl = join(repo, 'extra.ttl');
+    await writeFile(
+      aTtl,
+      '@prefix ex: <http://example.org/> .\nex:a a ex:Scheme .\n',
+    );
+    await writeFile(
+      extraTtl,
+      '@prefix ex: <http://example.org/> .\nex:extra a ex:Scheme .\n',
+    );
+    await git(repo, ['init', '-q', '-b', 'main']);
+    await git(repo, ['add', '.']);
+    await git(repo, ['commit', '-q', '-m', 'both files']);
+    await git(repo, ['branch', 'has-extra']);
+    // Drop extra.ttl from main's working tree so it exists only at `has-extra`.
+    await rm(extraTtl, { force: true });
+    await git(repo, ['add', '-A']);
+    await git(repo, ['commit', '-q', '-m', 'drop extra']);
+  }, 30_000);
+
+  afterEach(async () => {
+    if (repo) await rm(repo, { recursive: true, force: true });
+  });
+
+  it('enumerates the pinned glob against the git tree so a ref-only file appears in the diff', async () => {
+    const expanded = await expandSplitGlobs(
+      parseSourceSpecs([
+        { id: 'docs', glob: join(repo, '*.ttl'), splitByFile: true },
+      ]),
+      { walkGlob: defaultGlobWalker },
+    );
+    const engineMap = await EngineMap.create(expanded);
+    const svc = new DiffService(engineMap);
+
+    const select =
+      'PREFIX ex: <http://example.org/> SELECT DISTINCT ?s WHERE { ?s a ex:Scheme }';
+    const out = await svc.runDiff({
+      left: '@docs',
+      right: '@docs:has-extra',
+      leftQuery: select,
+      rightQuery: select,
+    });
+
+    expect(out.kind).toBe('tabular');
+    if (out.kind !== 'tabular') return;
+    expect(out.totals).toEqual({ left: 1, right: 2 });
+    expect(out.diff.added.map((e) => e.row['s']?.value)).toEqual([
+      'http://example.org/extra',
+    ]);
+    expect(out.diff.removed).toEqual([]);
+  });
+
+  it('enumerates a non-split pinned glob against the git tree (ref-only file appears)', async () => {
+    const registry = parseSourceSpecs([
+      { id: 'docs', glob: join(repo, '*.ttl') },
+    ]);
+    const engineMap = await EngineMap.create(registry);
+    const svc = new DiffService(engineMap);
+
+    const select =
+      'PREFIX ex: <http://example.org/> SELECT DISTINCT ?s WHERE { ?s a ex:Scheme }';
+    const out = await svc.runDiff({
+      left: '@docs',
+      right: '@docs:has-extra',
+      leftQuery: select,
+      rightQuery: select,
+    });
+
+    expect(out.kind).toBe('tabular');
+    if (out.kind !== 'tabular') return;
+    expect(out.totals).toEqual({ left: 1, right: 2 });
+    expect(out.diff.added.map((e) => e.row['s']?.value)).toEqual([
+      'http://example.org/extra',
+    ]);
+  });
+
+  it('enumerates the pinned glob against the git tree for a graph-mode CONSTRUCT diff', async () => {
+    const expanded = await expandSplitGlobs(
+      parseSourceSpecs([
+        { id: 'docs', glob: join(repo, '*.ttl'), splitByFile: true },
+      ]),
+      { walkGlob: defaultGlobWalker },
+    );
+    const engineMap = await EngineMap.create(expanded);
+    const svc = new DiffService(engineMap);
+
+    const construct =
+      'PREFIX ex: <http://example.org/> CONSTRUCT { ?s a ex:Scheme } WHERE { ?s a ex:Scheme }';
+    const out = await svc.runDiff({
+      left: '@docs',
+      right: '@docs:has-extra',
+      leftQuery: construct,
+      rightQuery: construct,
+    });
+
+    expect(out.kind).toBe('grouped');
+    if (out.kind !== 'grouped') return;
+    const anchors = out.hunked.hunks.map((h) => h.anchor);
+    expect(anchors).toContain('http://example.org/extra');
+    const extra = out.hunked.hunks.find(
+      (h) => h.anchor === 'http://example.org/extra',
+    );
+    expect(extra?.lines.every((l) => l.side === '+')).toBe(true);
+  });
+});
+
 describe('DiffService — pass-through boundary warn (ADR-0047, #376)', () => {
   function captureLogger() {
     return {

--- a/libs/server/src/lib/diff/diff.service.ts
+++ b/libs/server/src/lib/diff/diff.service.ts
@@ -13,12 +13,14 @@ import {
   tabularDiff,
   type DiffError,
   type HunkedRdfDiff,
+  type ParsedGlobSource,
   type ParsedSource,
   type RawPassThroughTargetError,
   type SelectShapeReport,
   type SourceError,
   type SourceRecordSidecar,
   type SourceSpecInput,
+  type SourceSpecObjectInput,
   type TabularDiffResult,
   type TabularRow,
 } from 'core';
@@ -385,10 +387,24 @@ function inlineQueryUpstream(
   target: ParsedSource,
   side: 'left' | 'right',
 ): Result<SourceSpecInput, DiffError> {
-  if (target.kind === 'glob') return ok(target.glob);
+  if (target.kind === 'glob') return ok(globUpstreamSpec(target));
   if (target.kind === 'file') return ok(target.path);
   if (target.kind === 'endpoint') return ok(target.endpoint);
   return err({ kind: 'inline-upstream-kind', side, targetKind: target.kind });
+}
+
+// A pinned glob must carry its `gitRef` (and `splitByFile`, so the resolver
+// enumerates the git tree at the SHA rather than the working tree) into the
+// inline-query upstream. A plain bare-glob string would drop the pin and
+// resolve both diff sides against the working tree — silently yielding zero
+// diff for files that exist only at the ref.
+function globUpstreamSpec(target: ParsedGlobSource): SourceSpecInput {
+  if (target.gitRef === undefined) return target.glob;
+  const spec: SourceSpecObjectInput = { glob: target.glob, gitRef: target.gitRef };
+  if (target.gitRoot !== undefined) spec.gitRoot = target.gitRoot;
+  if (target.splitByFile === true) spec.splitByFile = true;
+  if (target.id !== undefined) spec.id = target.id;
+  return spec;
 }
 
 function rawPassThroughRejection(


### PR DESCRIPTION
Diffing a glob source at a git ref (e.g. `@skos:origin/branch`) showed 0 diff when a file existed only at the ref.

## Root cause
Three layers dropped the git pin on the inline-query diff path:
1. `inlineQueryUpstream` returned the bare glob string, discarding `gitRef`/`splitByFile` → both sides resolved against the working tree.
2. The non-split pinned glob load enumerated via `tinyglobby` (working tree) and only read content at the SHA → ref-only files missed.
3. The inline-query executor (`loadUpstreamStore`) ignored `gitRef` entirely → CONSTRUCT/graph-mode diffs broken too.

## Fix
- Carry the pin through `inlineQueryUpstream`.
- Unify split/non-split pinned glob loads to enumerate from the git tree at the resolved SHA.
- Route pinned in-memory globs through `resolveSourceResult` in the inline executor.

## Tests
New diff-service tests with a ref-only file: tabular SELECT split-glob, non-split glob, and graph-mode CONSTRUCT. RED before, GREEN after. Full suites green (diff 18/18, core sources 390/390, inline-query 47/47).

Refs ADR-0029.